### PR TITLE
Rename docker repository to woo-publications-api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  IMAGE_NAME: maykinmedia/woo-publications
+  IMAGE_NAME: maykinmedia/woo-publications-api
   DJANGO_SETTINGS_MODULE: woo_publications.conf.ci
   DOCKER_BUILDKIT: '1'
 

--- a/README.EN.rst
+++ b/README.EN.rst
@@ -119,9 +119,9 @@ Licensed under the EUPL_
     :alt: Code style
     :target: https://github.com/psf/black
 
-.. |docker| image:: https://img.shields.io/docker/v/maykinmedia/woo-publications?sort=semver
+.. |docker| image:: https://img.shields.io/docker/v/maykinmedia/woo-publications-api?sort=semver
     :alt: Docker image
-    :target: https://hub.docker.com/r/maykinmedia/woo-publications
+    :target: https://hub.docker.com/r/maykinmedia/woo-publications-api
 
 .. |python-versions| image:: https://img.shields.io/badge/python-3.12%2B-blue.svg
     :alt: Supported Python version

--- a/README.rst
+++ b/README.rst
@@ -118,9 +118,9 @@ Licensed under the EUPL_
     :alt: Code style
     :target: https://github.com/psf/black
 
-.. |docker| image:: https://img.shields.io/docker/v/maykinmedia/woo-publications?sort=semver
+.. |docker| image:: https://img.shields.io/docker/v/maykinmedia/woo-publications-api?sort=semver
     :alt: Docker image
-    :target: https://hub.docker.com/r/maykinmedia/woo-publications
+    :target: https://hub.docker.com/r/maykinmedia/woo-publications-api
 
 .. |python-versions| image:: https://img.shields.io/badge/python-3.12%2B-blue.svg
     :alt: Supported Python version

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       context: .
       args:
         RELEASE: ${RELEASE:-latest}
-    image: maykinmedia/woo-publications:${RELEASE:-latest}
+    image: maykinmedia/woo-publications-api:${RELEASE:-latest}
     environment: &web_env
       - DJANGO_SETTINGS_MODULE=woo_publications.conf.docker
       - SECRET_KEY=${SECRET_KEY:-django-insecure-fgggi4*bl2wdg&@0&)t7ewy5-2!b3l4lhx4_+^zpw%x2i28v8}

--- a/src/woo_publications/templates/includes/footer.html
+++ b/src/woo_publications/templates/includes/footer.html
@@ -27,7 +27,7 @@
                     </a>
                 </li>
                 <li>
-                    <a class="link link--muted" href="https://hub.docker.com/r/maykinmedia/woo-publications">
+                    <a class="link link--muted" href="https://hub.docker.com/r/maykinmedia/woo-publications-api">
                         {% trans "Docker image" %}
                     </a>
                 </li>


### PR DESCRIPTION
Pending some token/permissions shenanigans in Docker Hub.

Later we will probably *also* publish this to GHCR