### PR TITLE
Add custom admin page for API resource URLs (for Documenten API)

### DIFF
--- a/docs/installation/requirements.rst
+++ b/docs/installation/requirements.rst
@@ -67,22 +67,12 @@ Documents API are based on these document types.
 
 Woo Publications requires the scopes listed above, for all information categories.
 
-You can construct the API resource URLs of the document
-types by taking the domain where Woo Publications is hosted (e.g.
-``https://woo-publications.example.com``) and concatenating the part
-``/catalogi/api/v1/informatieobjecttypen/`` and the UUID of each information category
-in the admin environment.
+The API resource URLs for all information categories are available on a page in the
+admin. Navigate to **Admin** > **Metadata** > **Information categories**. In the top
+right, click the **View API resource URLs** button.
 
-An example of a full resource URL is:
-``https://woo-publications.example.com/catalogi/api/v1/informatieobjecttypen/be4e21c2-0be5-4616-945e-1f101b0c0e6d``
-
-You can find the UUIDs by navigating to the **Admin** > **Metadata** >
-**Information categories** and then opening each category where you'll see the *UUID*
-field listed.
-
-.. note:: Currently this requires manual actions, we're developing a page to more easily
-   provide this information.
-
+The list page displays all information categories, grouped by their origin with the
+fully qualified resource URLs required by the Authorisations API.
 
 Known applications/products providing a Documents API
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/woo_publications/metadata/templates/admin/metadata/informationcategory/change_list_object_tools.html
+++ b/src/woo_publications/metadata/templates/admin/metadata/informationcategory/change_list_object_tools.html
@@ -1,0 +1,16 @@
+{% extends "admin/change_list_object_tools.html" %}
+{% load i18n %}
+
+{% block object-tools-items %}
+    {% url 'admin:metadata_informationcategory_iotendpoints' as overview_url %}
+
+    {% if request.path != overview_url %}
+        <li>
+            <a href="{{ overview_url }}" class=>
+                {% trans "View API resource URLs" %}
+            </a>
+        </li>
+    {% endif %}
+
+    {{ block.super }}
+{% endblock %}

--- a/src/woo_publications/metadata/templates/metadata/admin_information_category_api_resources.html
+++ b/src/woo_publications/metadata/templates/metadata/admin_information_category_api_resources.html
@@ -1,0 +1,57 @@
+{% extends "admin/change_list.html" %}
+{% load i18n admin_urls admin_list %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:metadata_informationcategory_changelist'  %}">{{ opts.verbose_name_plural|capfirst }}</a>
+&rsaquo; {% trans "Information object type API resource URLs" %}
+</div>
+{% endblock %}
+
+{% block search %}{% endblock %}
+
+{% block result_list %}
+<div class="results">
+    <table id="result_list">
+        <thead>
+            <tr>
+                <th scope="col">
+                    <div class="text"><span>{% trans "name" %}</span></div>
+                </th>
+                <th scope="col">
+                    <div class="text"><span>{% trans "resource URI" %}</span></div>
+                </th>
+            </tr>
+        </thead>
+
+        <tbody>
+            {% for category in information_categories %}
+
+                {% ifchanged category.oorsprong %}
+                    </tbody>
+                    <tbody>
+                        <tr>
+                            <td colspan="2">
+                                <strong>
+                                    {% filter capfirst %}{% trans "origin" %}: {% endfilter %}
+                                </strong>
+                                {{ category.get_oorsprong_display }}
+                            </td>
+                        </tr>
+                {% endifchanged %}
+
+                <tr>
+                    <td>{{ category.naam }}</td>
+                    <td>
+                        <code>{{ url_prefix }}{% url 'catalogi-informatieobjecttypen-detail' uuid=category.uuid %}</code>
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}
+
+{% block pagination %}{% endblock %}
+{% block filters %}{% endblock %}


### PR DESCRIPTION
Fixes #131

**Changes**

* Added a custom admin page listing all the API resource URLs that need to be configured in the Autorisaties API
* Updated documentation

