### PR TITLE
Document date(time) query params

### DIFF
--- a/src/woo_publications/api/openapi.yaml
+++ b/src/woo_publications/api/openapi.yaml
@@ -92,6 +92,18 @@ paths:
           The display name of the user performing the action, to make them recognizable.
         required: true
       - in: query
+        name: creatiedatumTot
+        schema:
+          type: string
+          format: date-time
+        description: Filter documents that were created before the given value.
+      - in: query
+        name: creatiedatumVanaf
+        schema:
+          type: string
+          format: date-time
+        description: Filter documents that were created after or on the given value.
+      - in: query
         name: eigenaar
         schema:
           type: string
@@ -101,6 +113,19 @@ paths:
         schema:
           type: string
         description: Search the document based on the identifier field.
+      - in: query
+        name: laatstGewijzigdDatumTot
+        schema:
+          type: string
+          format: date-time
+        description: Filter documents that were last modified before the given value.
+      - in: query
+        name: laatstGewijzigdDatumVanaf
+        schema:
+          type: string
+          format: date-time
+        description: Filter documents that were last modified after or on the given
+          value.
       - name: page
         required: false
         in: query
@@ -135,6 +160,18 @@ paths:
           * `gepubliceerd` - Gepubliceerd
           * `concept` - Concept
           * `ingetrokken` - Ingetrokken
+      - in: query
+        name: registratiedatumTot
+        schema:
+          type: string
+          format: date-time
+        description: Filter documents that were registered before the given value.
+      - in: query
+        name: registratiedatumVanaf
+        schema:
+          type: string
+          format: date-time
+        description: Filter documents that were registered after or on the given value.
       - in: query
         name: sorteer
         schema:

--- a/src/woo_publications/publications/api/filters.py
+++ b/src/woo_publications/publications/api/filters.py
@@ -21,6 +21,40 @@ class DocumentFilterSet(FilterSet):
             "**Disclaimer**: disregard the documented type `integer` the correct type is `UUID`."
         ),
     )
+    registratiedatum_vanaf = filters.DateTimeFilter(
+        help_text=_(
+            "Filter documents that were registered after or on the given value."
+        ),
+        field_name="registratiedatum",
+        lookup_expr="gte",
+    )
+    registratiedatum_tot = filters.DateTimeFilter(
+        help_text=_("Filter documents that were registered before the given value."),
+        field_name="registratiedatum",
+        lookup_expr="lt",
+    )
+    creatiedatum_vanaf = filters.DateTimeFilter(
+        help_text=_("Filter documents that were created after or on the given value."),
+        field_name="creatiedatum",
+        lookup_expr="gte",
+    )
+    creatiedatum_tot = filters.DateTimeFilter(
+        help_text=_("Filter documents that were created before the given value."),
+        field_name="creatiedatum",
+        lookup_expr="lt",
+    )
+    laatst_gewijzigd_datum_vanaf = filters.DateTimeFilter(
+        help_text=_(
+            "Filter documents that were last modified after or on the given value."
+        ),
+        field_name="laatst_gewijzigd_datum",
+        lookup_expr="gte",
+    )
+    laatst_gewijzigd_datum_tot = filters.DateTimeFilter(
+        help_text=_("Filter documents that were last modified before the given value."),
+        field_name="laatst_gewijzigd_datum",
+        lookup_expr="lt",
+    )
     eigenaar = OwnerFilter(
         help_text=_("Filter documents based on the owner identifier of the object."),
     )
@@ -47,6 +81,12 @@ class DocumentFilterSet(FilterSet):
             "eigenaar",
             "publicatiestatus",
             "identifier",
+            "registratiedatum_vanaf",
+            "registratiedatum_tot",
+            "creatiedatum_vanaf",
+            "creatiedatum_tot",
+            "laatst_gewijzigd_datum_vanaf",
+            "laatst_gewijzigd_datum_tot",
             "sorteer",
         )
 

--- a/src/woo_publications/publications/tests/test_document_api_endpoints.py
+++ b/src/woo_publications/publications/tests/test_document_api_endpoints.py
@@ -496,6 +496,226 @@ class DocumentApiReadTests(TokenAuthMixin, APITestCase):
             self.assertEqual(data["count"], 1)
             self.assertEqual(data["results"][0]["uuid"], str(revoked.uuid))
 
+    def test_list_documents_filter_registratie_datum(self):
+        with freeze_time("2024-09-24T12:00:00-00:00"):
+            document = DocumentFactory.create()
+        with freeze_time("2024-09-25T12:00:00-00:00"):
+            document2 = DocumentFactory.create()
+        with freeze_time("2024-09-26T12:00:00-00:00"):
+            document3 = DocumentFactory.create()
+
+        list_url = reverse("api:document-list")
+
+        with self.subTest("gte specific tests"):
+            with self.subTest("filter on gte date is exact match"):
+                response = self.client.get(
+                    list_url,
+                    {"registratiedatumVanaf": "2024-09-26T12:00:00-00:00"},
+                    headers=AUDIT_HEADERS,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+
+                self.assertEqual(data["count"], 1)
+                self.assertEqual(data["results"][0]["uuid"], str(document3.uuid))
+
+            with self.subTest("filter on gte date is greater then publication"):
+                response = self.client.get(
+                    list_url,
+                    {"registratiedatumVanaf": "2024-09-26T00:00:00-00:00"},
+                    headers=AUDIT_HEADERS,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+
+                self.assertEqual(data["count"], 1)
+                self.assertEqual(data["results"][0]["uuid"], str(document3.uuid))
+
+        with self.subTest("lt specific tests"):
+            with self.subTest("filter on lt date is exact match"):
+                response = self.client.get(
+                    list_url,
+                    {"registratiedatumTot": "2024-09-24T12:00:01-00:00"},
+                    headers=AUDIT_HEADERS,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+
+                self.assertEqual(data["count"], 1)
+                self.assertEqual(data["results"][0]["uuid"], str(document.uuid))
+
+        with self.subTest(
+            "filter both lt and gte to find publication between two dates"
+        ):
+            with self.subTest("filter on lt date is lesser then publication"):
+                response = self.client.get(
+                    list_url,
+                    {
+                        "registratiedatumVanaf": "2024-09-25T00:00:00-00:00",
+                        "registratiedatumTot": "2024-09-26T00:00:00-00:00",
+                    },
+                    headers=AUDIT_HEADERS,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+
+                self.assertEqual(data["count"], 1)
+                self.assertEqual(data["results"][0]["uuid"], str(document2.uuid))
+
+    def test_list_documents_filter_creatie_datum(self):
+        document = DocumentFactory.create(creatiedatum="2024-09-24")
+        document2 = DocumentFactory.create(creatiedatum="2024-09-25")
+        DocumentFactory.create(creatiedatum="2024-09-26")
+        document4 = DocumentFactory.create(creatiedatum="2024-09-28")
+
+        list_url = reverse("api:document-list")
+
+        with self.subTest("gte specific tests"):
+            with self.subTest("filter on gte date is exact match"):
+                response = self.client.get(
+                    list_url,
+                    {"creatiedatumVanaf": "2024-09-28"},
+                    headers=AUDIT_HEADERS,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+
+                self.assertEqual(data["count"], 1)
+                self.assertEqual(data["results"][0]["uuid"], str(document4.uuid))
+
+            with self.subTest("filter on gte date is greater then publication"):
+                response = self.client.get(
+                    list_url,
+                    {"creatiedatumVanaf": "2024-09-27"},
+                    headers=AUDIT_HEADERS,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+
+                self.assertEqual(data["count"], 1)
+                self.assertEqual(data["results"][0]["uuid"], str(document4.uuid))
+
+        with self.subTest("lt specific tests"):
+            with self.subTest("filter on lt date is lesser then publication"):
+                response = self.client.get(
+                    list_url,
+                    {"creatiedatumTot": "2024-09-25"},
+                    headers=AUDIT_HEADERS,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+
+                self.assertEqual(data["count"], 1)
+                self.assertEqual(data["results"][0]["uuid"], str(document.uuid))
+
+        with self.subTest(
+            "filter both lt and gte to find publication between two dates"
+        ):
+            with self.subTest("filter on lt date is lesser then publication"):
+                response = self.client.get(
+                    list_url,
+                    {
+                        "creatiedatumVanaf": "2024-09-25",
+                        "creatiedatumTot": "2024-09-26",
+                    },
+                    headers=AUDIT_HEADERS,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+
+                self.assertEqual(data["count"], 1)
+                self.assertEqual(data["results"][0]["uuid"], str(document2.uuid))
+
+    def test_list_documents_filter_laatst_gewijzigd_datum(self):
+        with freeze_time("2024-09-24T12:00:00-00:00"):
+            document = DocumentFactory.create()
+        with freeze_time("2024-09-25T12:00:00-00:00"):
+            document2 = DocumentFactory.create()
+        with freeze_time("2024-09-26T12:00:00-00:00"):
+            document3 = DocumentFactory.create()
+
+        list_url = reverse("api:document-list")
+
+        with self.subTest("gte specific tests"):
+            with self.subTest("filter on gte date is exact match"):
+                response = self.client.get(
+                    list_url,
+                    {"laatstGewijzigdDatumVanaf": "2024-09-26T12:00:00-00:00"},
+                    headers=AUDIT_HEADERS,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+
+                self.assertEqual(data["count"], 1)
+                self.assertEqual(data["results"][0]["uuid"], str(document3.uuid))
+
+            with self.subTest("filter on gte date is greater then publication"):
+                response = self.client.get(
+                    list_url,
+                    {"laatstGewijzigdDatumVanaf": "2024-09-26T00:00:00-00:00"},
+                    headers=AUDIT_HEADERS,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+
+                self.assertEqual(data["count"], 1)
+                self.assertEqual(data["results"][0]["uuid"], str(document3.uuid))
+
+        with self.subTest("lt specific tests"):
+            with self.subTest("filter on lt date is lesser then publication"):
+                response = self.client.get(
+                    list_url,
+                    {"laatstGewijzigdDatumTot": "2024-09-25T00:00:00-00:00"},
+                    headers=AUDIT_HEADERS,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+
+                self.assertEqual(data["count"], 1)
+                self.assertEqual(data["results"][0]["uuid"], str(document.uuid))
+
+        with self.subTest(
+            "filter both lt and gte to find publication between two dates"
+        ):
+            with self.subTest("filter on lt date is lesser then publication"):
+                response = self.client.get(
+                    list_url,
+                    {
+                        "laatstGewijzigdDatumVanaf": "2024-09-25T00:00:00-00:00",
+                        "laatstGewijzigdDatumTot": "2024-09-26T00:00:00-00:00",
+                    },
+                    headers=AUDIT_HEADERS,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+
+                self.assertEqual(data["count"], 1)
+                self.assertEqual(data["results"][0]["uuid"], str(document2.uuid))
+
     def test_detail_document(self):
         publication = PublicationFactory.create()
         with freeze_time("2024-09-25T12:30:00-00:00"):

--- a/src/woo_publications/publications/tests/test_publications_api.py
+++ b/src/woo_publications/publications/tests/test_publications_api.py
@@ -323,7 +323,7 @@ class PublicationApiTests(TokenAuthMixin, APITestCase):
         with freeze_time("2024-09-26T12:00:00-00:00"):
             publication3 = PublicationFactory.create(informatie_categorieen=[ic])
 
-        with self.subTest("lte specific tests"):
+        with self.subTest("gte specific tests"):
             with self.subTest("filter on gte date is exact match"):
                 response = self.client.get(
                     reverse("api:publication-list"),
@@ -352,22 +352,8 @@ class PublicationApiTests(TokenAuthMixin, APITestCase):
                 self.assertEqual(data["count"], 1)
                 self.assertEqual(data["results"][0]["uuid"], str(publication3.uuid))
 
-        with self.subTest("lte specific tests"):
-            with self.subTest("filter on lte date is exact match"):
-                response = self.client.get(
-                    reverse("api:publication-list"),
-                    {"registratiedatumTot": "2024-09-24T12:00:01-00:00"},
-                    headers=AUDIT_HEADERS,
-                )
-
-                self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-                data = response.json()
-
-                self.assertEqual(data["count"], 1)
-                self.assertEqual(data["results"][0]["uuid"], str(publication.uuid))
-
-            with self.subTest("filter on lte date is lesser then publication"):
+        with self.subTest("lt specific tests"):
+            with self.subTest("filter on lt date is lesser then publication"):
                 response = self.client.get(
                     reverse("api:publication-list"),
                     {"registratiedatumTot": "2024-09-25T00:00:00-00:00"},
@@ -382,9 +368,9 @@ class PublicationApiTests(TokenAuthMixin, APITestCase):
                 self.assertEqual(data["results"][0]["uuid"], str(publication.uuid))
 
         with self.subTest(
-            "filter both lte and gte to find publication between two dates"
+            "filter both lt and gte to find publication between two dates"
         ):
-            with self.subTest("filter on lte date is lesser then publication"):
+            with self.subTest("filter on lt date is lesser then publication"):
                 response = self.client.get(
                     reverse("api:publication-list"),
                     {


### PR DESCRIPTION
Fixes #157 

**Changes**

Added gte and lt filters for document fields:
- creatiedatum
- regestratiedatum
- laatst_gewijzigd_datum

