### PR TITLE
Information category query param with inspanningsverplichting 

### DIFF
--- a/src/woo_publications/api/openapi.yaml
+++ b/src/woo_publications/api/openapi.yaml
@@ -114,6 +114,18 @@ paths:
           type: string
         description: Search the document based on the identifier field.
       - in: query
+        name: informatieCategorieen
+        schema:
+          type: array
+          items:
+            type: string
+        description: |-
+          Filter documents that belong to a particular information category. When you specify multiple categories, documents belonging to any category are returned.
+
+          Filter values should be the UUID of the categories.
+        explode: true
+        style: form
+      - in: query
         name: laatstGewijzigdDatumTot
         schema:
           type: string
@@ -1024,7 +1036,6 @@ paths:
           type: array
           items:
             type: string
-            format: uuid
         description: |-
           Filter publicaties die binnen een bepaalde informatiecategorie vallen. Als je meerdere categorieën opgeeft, dan krijg je alle publicaties die aan één van deze categorieën gerelateerd zijn.
 

--- a/src/woo_publications/api/tests/mixins.py
+++ b/src/woo_publications/api/tests/mixins.py
@@ -3,9 +3,9 @@ from typing import Any
 from django.utils.translation import gettext as _
 
 from rest_framework import status
-from rest_framework.test import APIClient, APITestCase
+from rest_framework.test import APIClient
 
-from woo_publications.typing import JSON
+from woo_publications.typing import JSONObject
 
 from .factories import TokenAuthFactory
 
@@ -253,8 +253,8 @@ class APIKeyUnAuthorizedMixin:
 class APITestCaseMixin:
 
     def assertItemInResults(
-        self: APITestCase,  # pyright: ignore [reportGeneralTypeIssues]
-        results: JSON,
+        self,
+        results: list[JSONObject],
         key: str,
         value: Any,
         count: int | None = None,
@@ -272,10 +272,14 @@ class APITestCaseMixin:
         items_found: int = values.count(value)
 
         if count:
-            self.assertEqual(items_found, count)
+            self.assertEqual(  # pyright: ignore [reportAttributeAccessIssue]
+                items_found, count
+            )
 
         else:
-            self.assertTrue(items_found >= 1)
+            self.assertTrue(  # pyright: ignore [reportAttributeAccessIssue]
+                items_found >= 1
+            )
 
 
 class TokenAuthMixin:

--- a/src/woo_publications/api/tests/mixins.py
+++ b/src/woo_publications/api/tests/mixins.py
@@ -1,5 +1,11 @@
+from typing import Any
+
+from django.utils.translation import gettext as _
+
 from rest_framework import status
-from rest_framework.test import APIClient
+from rest_framework.test import APIClient, APITestCase
+
+from woo_publications.typing import JSON
 
 from .factories import TokenAuthFactory
 
@@ -242,6 +248,34 @@ class APIKeyUnAuthorizedMixin:
             self.assertEqual(  # pyright: ignore[reportAttributeAccessIssue]
                 response.status_code, status.HTTP_403_FORBIDDEN
             )
+
+
+class APITestCaseMixin:
+
+    def assertItemInResults(
+        self: APITestCase,  # pyright: ignore [reportGeneralTypeIssues]
+        results: JSON,
+        key: str,
+        value: Any,
+        count: int | None = None,
+    ) -> None:
+        """
+        Custom assert to validate if value of key is in api results.
+        """
+        try:
+            values: list[Any] = [result[key] for result in results]
+        except KeyError:
+            raise AssertionError(
+                _("Key '{key}' not found in the given results.").format(key=key)
+            )
+
+        items_found: int = values.count(value)
+
+        if count:
+            self.assertEqual(items_found, count)
+
+        else:
+            self.assertTrue(items_found >= 1)
 
 
 class TokenAuthMixin:

--- a/src/woo_publications/conf/base.py
+++ b/src/woo_publications/conf/base.py
@@ -79,6 +79,11 @@ LOGIN_URLS = [reverse_lazy("admin:login")]
 # Default (connection timeout, read timeout) for the requests library (in seconds)
 REQUESTS_DEFAULT_TIMEOUT = (10, 30)
 
+# The Identifier of `inspanningsverplichting` from the gov origins list for the Information Categories.
+INSPANNINGSVERPLICHTING_IDENTIFIER = (
+    "https://identifier.overheid.nl/tooi/def/thes/kern/c_816e508d"
+)
+
 ##############################
 #                            #
 # 3RD PARTY LIBRARY SETTINGS #

--- a/src/woo_publications/publications/tests/test_document_api_endpoints.py
+++ b/src/woo_publications/publications/tests/test_document_api_endpoints.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterator
 from uuid import uuid4
 
+from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.http import StreamingHttpResponse
 from django.test import override_settings
@@ -19,6 +20,7 @@ from woo_publications.contrib.documents_api.client import get_client
 from woo_publications.contrib.documents_api.tests.factories import ServiceFactory
 from woo_publications.logging.logevent import audit_api_create
 from woo_publications.logging.serializing import serialize_instance
+from woo_publications.metadata.constants import InformationCategoryOrigins
 from woo_publications.metadata.tests.factories import (
     InformationCategoryFactory,
     OrganisationFactory,
@@ -715,6 +717,101 @@ class DocumentApiReadTests(TokenAuthMixin, APITestCase):
 
                 self.assertEqual(data["count"], 1)
                 self.assertEqual(data["results"][0]["uuid"], str(document2.uuid))
+
+    def test_list_document_filter_information_categories(self):
+        ic, ic2, ic3, ic4 = InformationCategoryFactory.create_batch(
+            4, oorsprong=InformationCategoryOrigins.value_list
+        )
+        (
+            custom_ic,
+            custom_ic2,
+        ) = InformationCategoryFactory.create_batch(
+            2, oorsprong=InformationCategoryOrigins.custom_entry
+        )
+        inspanningsverplichting_ic = InformationCategoryFactory.create(
+            oorsprong=InformationCategoryOrigins.value_list,
+            identifier=settings.INSPANNINGSVERPLICHTING_IDENTIFIER,
+        )
+        publication = PublicationFactory.create(informatie_categorieen=[ic])
+        publication2 = PublicationFactory.create(informatie_categorieen=[ic2])
+        publication3 = PublicationFactory.create(informatie_categorieen=[ic3, ic4])
+        publication4 = PublicationFactory.create(informatie_categorieen=[custom_ic])
+        publication5 = PublicationFactory.create(informatie_categorieen=[custom_ic2])
+        publication6 = PublicationFactory.create(
+            informatie_categorieen=[inspanningsverplichting_ic]
+        )
+        document = DocumentFactory.create(publicatie=publication)
+        document2 = DocumentFactory.create(publicatie=publication2)
+        document3 = DocumentFactory.create(publicatie=publication3)
+        document4 = DocumentFactory.create(publicatie=publication4)
+        document5 = DocumentFactory.create(publicatie=publication5)
+        document6 = DocumentFactory.create(publicatie=publication6)
+
+        list_url = reverse("api:document-list")
+
+        with self.subTest("filter on a single information category"):
+            response = self.client.get(
+                list_url,
+                {"informatieCategorieen": str(ic.uuid)},
+                headers=AUDIT_HEADERS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            data = response.json()
+
+            self.assertEqual(data["count"], 1)
+            self.assertEqual(data["results"][0]["uuid"], str(document.uuid))
+
+        with self.subTest("filter on multiple information categories "):
+            response = self.client.get(
+                list_url,
+                {"informatieCategorieen": f"{ic2.uuid},{ic4.uuid}"},
+                headers=AUDIT_HEADERS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            data = response.json()
+
+            self.assertEqual(data["count"], 2)
+
+            self.assertContains(response, str(document2.uuid), 1)
+            self.assertContains(response, str(document3.uuid), 1)
+
+        with self.subTest("filter on the insappingsverplichting category"):
+            response = self.client.get(
+                list_url,
+                {"informatieCategorieen": f"{inspanningsverplichting_ic.uuid}"},
+                headers=AUDIT_HEADERS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            data = response.json()
+
+            self.assertEqual(data["count"], 3)
+
+            self.assertContains(response, str(document4.uuid), 1)
+            self.assertContains(response, str(document5.uuid), 1)
+            self.assertContains(response, str(document6.uuid), 1)
+
+        with self.subTest("filter with invalid uuid"):
+            fake_ic = uuid4()
+            response = self.client.get(
+                list_url,
+                {"informatieCategorieen": f"{fake_ic}"},
+                headers=AUDIT_HEADERS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+            data = response.json()
+            error_message = _(
+                "Select a valid choice. %(value)s is not one of the available choices."
+            ) % {"value": str(fake_ic)}
+
+            self.assertEqual(data["informatieCategorieen"], [error_message])
 
     def test_detail_document(self):
         publication = PublicationFactory.create()

--- a/src/woo_publications/typing.py
+++ b/src/woo_publications/typing.py
@@ -1,4 +1,3 @@
 type JSONPrimitive = str | int | float | bool | None
 type JSONValue = JSONPrimitive | JSONObject | list[JSONValue]
 type JSONObject = dict[str, JSONValue]
-type JSON = list[JSONObject]

--- a/src/woo_publications/typing.py
+++ b/src/woo_publications/typing.py
@@ -1,3 +1,4 @@
 type JSONPrimitive = str | int | float | bool | None
 type JSONValue = JSONPrimitive | JSONObject | list[JSONValue]
 type JSONObject = dict[str, JSONValue]
+type JSON = list[JSONObject]


### PR DESCRIPTION
Fixes #73

**Changes**

- Added information_category filter for documents api
- Added functionality when the information_category is the `inspanningsverplichting` that all custom information categories gets include in the filter.
- Made the information_category filter func generic because it works the exact same way for both usecases.