### PR TITLE
Sitemap information categorie field.

### DIFF
--- a/src/woo_publications/api/openapi.yaml
+++ b/src/woo_publications/api/openapi.yaml
@@ -2212,6 +2212,13 @@ components:
             format: uuid
           description: De informatiecategorie verduidelijkt de soort informatie die
             in de publicatie voorkomt.
+        diWooInformatieCategorieen:
+          type: array
+          items:
+            type: string
+            format: uuid
+          readOnly: true
+          description: The information categories used for the sitemap
         publisher:
           type: string
           format: uuid
@@ -2295,6 +2302,13 @@ components:
             format: uuid
           description: De informatiecategorie verduidelijkt de soort informatie die
             in de publicatie voorkomt.
+        diWooInformatieCategorieen:
+          type: array
+          items:
+            type: string
+            format: uuid
+          readOnly: true
+          description: The information categories used for the sitemap
         publisher:
           type: string
           format: uuid
@@ -2355,6 +2369,7 @@ components:
           description: Systeemdatum en -tijd wanneer de publicatie laatst gewijzigd
             is in de database.
       required:
+      - diWooInformatieCategorieen
       - eigenaar
       - informatieCategorieen
       - laatstGewijzigdDatum

--- a/src/woo_publications/publications/api/serializers.py
+++ b/src/woo_publications/publications/api/serializers.py
@@ -219,6 +219,12 @@ class PublicationSerializer(serializers.ModelSerializer[Publication]):
         many=True,
         allow_empty=False,
     )
+    di_woo_informatie_categorieen = serializers.ListField(
+        child=serializers.UUIDField(),
+        source="get_diwoo_informatie_categorieen_uuids",
+        help_text=_("The information categories used for the sitemap"),
+        read_only=True,
+    )
     publisher = serializers.SlugRelatedField(
         queryset=Organisation.objects.filter(is_actief=True),
         slug_field="uuid",
@@ -249,6 +255,7 @@ class PublicationSerializer(serializers.ModelSerializer[Publication]):
         fields = (
             "uuid",
             "informatie_categorieen",
+            "di_woo_informatie_categorieen",
             "publisher",
             "verantwoordelijke",
             "opsteller",

--- a/src/woo_publications/publications/models.py
+++ b/src/woo_publications/publications/models.py
@@ -2,6 +2,7 @@ import uuid
 from typing import Callable
 from uuid import UUID
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files import File
 from django.db import models, transaction
@@ -26,6 +27,7 @@ from woo_publications.logging.service import (
 from woo_publications.logging.typing import ActingUser
 from woo_publications.metadata.models import InformationCategory
 
+from ..metadata.constants import InformationCategoryOrigins
 from .constants import DocumentActionTypeOptions, PublicationStatusOptions
 from .typing import DocumentActions
 
@@ -166,6 +168,27 @@ class Publication(ModelOwnerMixin, models.Model):
                 object_data=serialize_instance(document),
                 **log_extra_kwargs,  # pyright: ignore[reportArgumentType]
             )
+
+    # TODO: refactor code to make it actually performant.
+    @property
+    def get_diwoo_informatie_categorieen_uuids(
+        self,
+    ) -> models.QuerySet[InformationCategory, UUID]:
+        information_categories = self.informatie_categorieen
+        ic_value_list = information_categories.filter(
+            oorsprong=InformationCategoryOrigins.value_list
+        )
+
+        if information_categories.filter(
+            oorsprong=InformationCategoryOrigins.custom_entry
+        ).exists():
+            inspannings_verplicht = InformationCategory.objects.filter(
+                identifier=settings.INSPANNINGSVERPLICHTING_IDENTIFIER
+            )
+
+            ic_value_list |= inspannings_verplicht
+
+        return ic_value_list.distinct().values_list("uuid", flat=True)
 
 
 class Document(ModelOwnerMixin, models.Model):

--- a/src/woo_publications/publications/models.py
+++ b/src/woo_publications/publications/models.py
@@ -25,9 +25,9 @@ from woo_publications.logging.service import (
     audit_api_update,
 )
 from woo_publications.logging.typing import ActingUser
+from woo_publications.metadata.constants import InformationCategoryOrigins
 from woo_publications.metadata.models import InformationCategory
 
-from ..metadata.constants import InformationCategoryOrigins
 from .constants import DocumentActionTypeOptions, PublicationStatusOptions
 from .typing import DocumentActions
 


### PR DESCRIPTION
Fixes #73 [marco's [comment](https://github.com/GPP-Woo/GPP-publicatiebank/issues/73#issuecomment-2520309076)]

**Changes**

Added custom information categories field which filters out all the custom added information categories and replaces them with the inspannings verplicht object instead.

