### PR TITLE
Manage GPP Zoeken index from publicatiebank

### DIFF
--- a/src/woo_publications/contrib/gpp_zoeken/client.py
+++ b/src/woo_publications/contrib/gpp_zoeken/client.py
@@ -18,6 +18,7 @@ from .typing import (
     IndexDocumentResponse,
     IndexPublicationBody,
     IndexPublicationResponse,
+    RemoveDocumentFromIndexResponse,
 )
 
 __all__ = ["get_client"]
@@ -57,6 +58,16 @@ class GPPSearchClient(NLXClient):
         response.raise_for_status()
 
         response_data: IndexDocumentResponse = response.json()
+        return response_data["taskId"]
+
+    def remove_document_from_index(self, document: Document) -> str:
+        if document.publicatiestatus == PublicationStatusOptions.published:
+            raise ValueError("The document has 'published' status!")
+
+        response = self.delete(f"documenten/{document.uuid}")
+        response.raise_for_status()
+
+        response_data: RemoveDocumentFromIndexResponse = response.json()
         return response_data["taskId"]
 
     def index_publication(self, publication: Publication):

--- a/src/woo_publications/contrib/gpp_zoeken/client.py
+++ b/src/woo_publications/contrib/gpp_zoeken/client.py
@@ -19,6 +19,7 @@ from .typing import (
     IndexPublicationBody,
     IndexPublicationResponse,
     RemoveDocumentFromIndexResponse,
+    RemovePublicationFromIndexResponse,
 )
 
 __all__ = ["get_client"]
@@ -102,4 +103,14 @@ class GPPSearchClient(NLXClient):
         response.raise_for_status()
 
         response_data: IndexPublicationResponse = response.json()
+        return response_data["taskId"]
+
+    def remove_publication_from_index(self, publication: Publication) -> str:
+        if publication.publicatiestatus == PublicationStatusOptions.published:
+            raise ValueError("The publication has 'published' status!")
+
+        response = self.delete(f"publicaties/{publication.uuid}")
+        response.raise_for_status()
+
+        response_data: RemovePublicationFromIndexResponse = response.json()
         return response_data["taskId"]

--- a/src/woo_publications/contrib/gpp_zoeken/tests/test_client.py
+++ b/src/woo_publications/contrib/gpp_zoeken/tests/test_client.py
@@ -101,3 +101,35 @@ class SearchClientTests(VCRMixin, TestCase):
         self.assertIsNotNone(task_id)
         self.assertIsInstance(task_id, str)
         self.assertNotEqual(task_id, "")
+
+    def test_remove_unpublished_publication_from_index(self):
+        service = ServiceFactory.build(for_gpp_search_docker_compose=True)
+
+        for publication_status in PublicationStatusOptions:
+            if publication_status == PublicationStatusOptions.published:
+                continue
+
+            doc = PublicationFactory.build(
+                publicatiestatus=publication_status,
+                uuid="5e033c6c-6430-46c1-9efd-05899ec63382",
+            )
+
+            with self.subTest(publication_status), get_client(service) as client:
+                task_id = client.remove_publication_from_index(doc)
+
+                self.assertIsNotNone(task_id)
+                self.assertIsInstance(task_id, str)
+                self.assertNotEqual(task_id, "")
+
+    def test_remove_published_publication_from_index(self):
+        service = ServiceFactory.build(for_gpp_search_docker_compose=True)
+
+        doc = PublicationFactory.create(
+            publicatiestatus=PublicationStatusOptions.published
+        )
+
+        with (
+            get_client(service) as client,
+            self.assertRaises(ValueError),
+        ):
+            client.remove_publication_from_index(doc)

--- a/src/woo_publications/contrib/gpp_zoeken/tests/test_client.py
+++ b/src/woo_publications/contrib/gpp_zoeken/tests/test_client.py
@@ -41,6 +41,38 @@ class SearchClientTests(VCRMixin, TestCase):
         self.assertIsInstance(task_id, str)
         self.assertNotEqual(task_id, "")
 
+    def test_remove_unpublished_document_from_index(self):
+        service = ServiceFactory.build(for_gpp_search_docker_compose=True)
+
+        for publication_status in PublicationStatusOptions:
+            if publication_status == PublicationStatusOptions.published:
+                continue
+
+            doc = DocumentFactory.build(
+                publicatiestatus=publication_status,
+                uuid="5e033c6c-6430-46c1-9efd-05899ec63382",
+            )
+
+            with self.subTest(publication_status), get_client(service) as client:
+                task_id = client.remove_document_from_index(doc)
+
+                self.assertIsNotNone(task_id)
+                self.assertIsInstance(task_id, str)
+                self.assertNotEqual(task_id, "")
+
+    def test_remove_published_document_from_index(self):
+        service = ServiceFactory.build(for_gpp_search_docker_compose=True)
+
+        doc = DocumentFactory.create(
+            publicatiestatus=PublicationStatusOptions.published
+        )
+
+        with (
+            get_client(service) as client,
+            self.assertRaises(ValueError),
+        ):
+            client.remove_document_from_index(doc)
+
     def test_index_unpublished_publication(self):
         service = ServiceFactory.build(for_gpp_search_docker_compose=True)
         client = get_client(service)

--- a/src/woo_publications/contrib/gpp_zoeken/tests/vcr_cassettes/test_client/SearchClientTests/test_remove_unpublished_document_from_index.yaml
+++ b/src/woo_publications/contrib/gpp_zoeken/tests/vcr_cassettes/test_client/SearchClientTests/test_remove_unpublished_document_from_index.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Token insecure-RySD8u5xkb9PH6AJtaZV4Y
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.32.3
+    method: DELETE
+    uri: http://localhost:8002/api/v1/documenten/5e033c6c-6430-46c1-9efd-05899ec63382
+  response:
+    body:
+      string: '{"taskId":"754ba5c2-2169-436f-9b83-020d2a8b14a5"}'
+    headers:
+      Allow:
+      - DELETE, OPTIONS
+      Content-Length:
+      - '49'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Token insecure-RySD8u5xkb9PH6AJtaZV4Y
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.32.3
+    method: DELETE
+    uri: http://localhost:8002/api/v1/documenten/5e033c6c-6430-46c1-9efd-05899ec63382
+  response:
+    body:
+      string: '{"taskId":"41bf1327-5a11-48a4-9654-73f64e1fc043"}'
+    headers:
+      Allow:
+      - DELETE, OPTIONS
+      Content-Length:
+      - '49'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 202
+      message: Accepted
+version: 1

--- a/src/woo_publications/contrib/gpp_zoeken/tests/vcr_cassettes/test_client/SearchClientTests/test_remove_unpublished_publication_from_index.yaml
+++ b/src/woo_publications/contrib/gpp_zoeken/tests/vcr_cassettes/test_client/SearchClientTests/test_remove_unpublished_publication_from_index.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Token insecure-RySD8u5xkb9PH6AJtaZV4Y
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.32.3
+    method: DELETE
+    uri: http://localhost:8002/api/v1/publicaties/5e033c6c-6430-46c1-9efd-05899ec63382
+  response:
+    body:
+      string: '{"taskId":"b8d6b087-f4b2-485a-8dc6-4c82e8689bdb"}'
+    headers:
+      Allow:
+      - DELETE, OPTIONS
+      Content-Length:
+      - '49'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Token insecure-RySD8u5xkb9PH6AJtaZV4Y
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.32.3
+    method: DELETE
+    uri: http://localhost:8002/api/v1/publicaties/5e033c6c-6430-46c1-9efd-05899ec63382
+  response:
+    body:
+      string: '{"taskId":"10674d17-2c63-406c-957f-bb1c1a340d93"}'
+    headers:
+      Allow:
+      - DELETE, OPTIONS
+      Content-Length:
+      - '49'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 202
+      message: Accepted
+version: 1

--- a/src/woo_publications/contrib/gpp_zoeken/typing.py
+++ b/src/woo_publications/contrib/gpp_zoeken/typing.py
@@ -39,5 +39,9 @@ class IndexDocumentResponse(TypedDict):
     taskId: str
 
 
+class RemoveDocumentFromIndexResponse(TypedDict):
+    taskId: str
+
+
 class IndexPublicationResponse(TypedDict):
     taskId: str

--- a/src/woo_publications/contrib/gpp_zoeken/typing.py
+++ b/src/woo_publications/contrib/gpp_zoeken/typing.py
@@ -45,3 +45,7 @@ class RemoveDocumentFromIndexResponse(TypedDict):
 
 class IndexPublicationResponse(TypedDict):
     taskId: str
+
+
+class RemovePublicationFromIndexResponse(TypedDict):
+    taskId: str

--- a/src/woo_publications/publications/api/viewsets.py
+++ b/src/woo_publications/publications/api/viewsets.py
@@ -139,6 +139,8 @@ class DocumentViewSet(
                 transaction.on_commit(
                     partial(remove_document_from_index.delay, document_id=document.pk)
                 )
+            case _:  # pragma: no cover
+                pass
 
     def get_serializer_class(self):
         action = getattr(self, "action", None)
@@ -370,3 +372,5 @@ class PublicationViewSet(AuditTrailViewSetMixin, viewsets.ModelViewSet):
                         publication_id=publication.pk,
                     )
                 )
+            case _:  # pragma: no cover
+                pass

--- a/src/woo_publications/publications/tasks.py
+++ b/src/woo_publications/publications/tasks.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Literal
+from typing import Literal, assert_never
 from uuid import UUID
 
 from woo_publications.celery import app
@@ -176,3 +176,5 @@ def remove_from_index_by_uuid(
                     uuid=uuid, publicatiestatus=PublicationStatusOptions.revoked
                 )
                 return client.remove_publication_from_index(publication)
+            case _:  # pragma: no cover
+                assert_never(model_name)

--- a/src/woo_publications/publications/tests/test_remove_document_from_index_task.py
+++ b/src/woo_publications/publications/tests/test_remove_document_from_index_task.py
@@ -66,3 +66,15 @@ class RemoveDocumentFromIndexTaskTests(VCRMixin, TestCase):
         self.assertIsNotNone(remote_task_id)
         self.assertIsInstance(remote_task_id, str)
         self.assertNotEqual(remote_task_id, "")
+
+    def test_remove_by_uuid_skipped_if_no_client_configured(self):
+        config = GlobalConfiguration.get_solo()
+        config.gpp_search_service = None
+        config.save()
+
+        remote_task_id = remove_from_index_by_uuid(
+            model_name="Document",
+            uuid="fc8fc2db-829e-48d5-83b2-0a9364bfe717",
+        )
+
+        self.assertIsNone(remote_task_id)

--- a/src/woo_publications/publications/tests/test_remove_document_from_index_task.py
+++ b/src/woo_publications/publications/tests/test_remove_document_from_index_task.py
@@ -5,7 +5,7 @@ from woo_publications.contrib.tests.factories import ServiceFactory
 from woo_publications.utils.tests.vcr import VCRMixin
 
 from ..constants import PublicationStatusOptions
-from ..tasks import remove_document_from_index
+from ..tasks import remove_document_from_index, remove_from_index_by_uuid
 from .factories import DocumentFactory
 
 
@@ -52,6 +52,16 @@ class RemoveDocumentFromIndexTaskTests(VCRMixin, TestCase):
         )
 
         remote_task_id = remove_document_from_index(document_id=doc.pk)
+
+        self.assertIsNotNone(remote_task_id)
+        self.assertIsInstance(remote_task_id, str)
+        self.assertNotEqual(remote_task_id, "")
+
+    def test_remove_by_uuid(self):
+        remote_task_id = remove_from_index_by_uuid(
+            model_name="Document",
+            uuid="fc8fc2db-829e-48d5-83b2-0a9364bfe717",
+        )
 
         self.assertIsNotNone(remote_task_id)
         self.assertIsInstance(remote_task_id, str)

--- a/src/woo_publications/publications/tests/test_remove_document_from_index_task.py
+++ b/src/woo_publications/publications/tests/test_remove_document_from_index_task.py
@@ -1,0 +1,57 @@
+from django.test import TestCase
+
+from woo_publications.config.models import GlobalConfiguration
+from woo_publications.contrib.tests.factories import ServiceFactory
+from woo_publications.utils.tests.vcr import VCRMixin
+
+from ..constants import PublicationStatusOptions
+from ..tasks import remove_document_from_index
+from .factories import DocumentFactory
+
+
+class RemoveDocumentFromIndexTaskTests(VCRMixin, TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        service = ServiceFactory.create(for_gpp_search_docker_compose=True)
+        GlobalConfiguration.objects.update_or_create(
+            pk=GlobalConfiguration.singleton_instance_id,
+            defaults={"gpp_search_service": service},
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.addCleanup(GlobalConfiguration.clear_cache)
+
+    def test_index_skipped_if_no_client_configured(self):
+        config = GlobalConfiguration.get_solo()
+        config.gpp_search_service = None
+        config.save()
+        doc = DocumentFactory.create(publicatiestatus=PublicationStatusOptions.revoked)
+
+        remote_task_id = remove_document_from_index(document_id=doc.pk)
+
+        self.assertIsNone(remote_task_id)
+
+    def test_index_skipped_for_published_document(self):
+        doc = DocumentFactory.create(
+            publicatiestatus=PublicationStatusOptions.published
+        )
+
+        remote_task_id = remove_document_from_index(document_id=doc.pk)
+
+        self.assertIsNone(remote_task_id)
+
+    def test_remove_revoked_document(self):
+        doc = DocumentFactory.create(
+            publicatiestatus=PublicationStatusOptions.revoked,
+            upload_complete=True,
+        )
+
+        remote_task_id = remove_document_from_index(document_id=doc.pk)
+
+        self.assertIsNotNone(remote_task_id)
+        self.assertIsInstance(remote_task_id, str)
+        self.assertNotEqual(remote_task_id, "")

--- a/src/woo_publications/publications/tests/test_remove_publication_from_index_task.py
+++ b/src/woo_publications/publications/tests/test_remove_publication_from_index_task.py
@@ -67,3 +67,15 @@ class RemovePublicationFromIndexTaskTests(VCRMixin, TestCase):
         self.assertIsNotNone(remote_task_id)
         self.assertIsInstance(remote_task_id, str)
         self.assertNotEqual(remote_task_id, "")
+
+    def test_remove_by_uuid_skipped_if_no_client_configured(self):
+        config = GlobalConfiguration.get_solo()
+        config.gpp_search_service = None
+        config.save()
+
+        remote_task_id = remove_from_index_by_uuid(
+            model_name="Publication",
+            uuid="86b4df60-36d6-478e-8866-1293a5eac725",
+        )
+
+        self.assertIsNone(remote_task_id)

--- a/src/woo_publications/publications/tests/test_remove_publication_from_index_task.py
+++ b/src/woo_publications/publications/tests/test_remove_publication_from_index_task.py
@@ -5,7 +5,7 @@ from woo_publications.contrib.tests.factories import ServiceFactory
 from woo_publications.utils.tests.vcr import VCRMixin
 
 from ..constants import PublicationStatusOptions
-from ..tasks import remove_publication_from_index
+from ..tasks import remove_from_index_by_uuid, remove_publication_from_index
 from .factories import PublicationFactory
 
 
@@ -53,6 +53,16 @@ class RemovePublicationFromIndexTaskTests(VCRMixin, TestCase):
         )
 
         remote_task_id = remove_publication_from_index(publication_id=publication.pk)
+
+        self.assertIsNotNone(remote_task_id)
+        self.assertIsInstance(remote_task_id, str)
+        self.assertNotEqual(remote_task_id, "")
+
+    def test_remove_by_uuid(self):
+        remote_task_id = remove_from_index_by_uuid(
+            model_name="Publication",
+            uuid="86b4df60-36d6-478e-8866-1293a5eac725",
+        )
 
         self.assertIsNotNone(remote_task_id)
         self.assertIsInstance(remote_task_id, str)

--- a/src/woo_publications/publications/tests/test_remove_publication_from_index_task.py
+++ b/src/woo_publications/publications/tests/test_remove_publication_from_index_task.py
@@ -5,11 +5,11 @@ from woo_publications.contrib.tests.factories import ServiceFactory
 from woo_publications.utils.tests.vcr import VCRMixin
 
 from ..constants import PublicationStatusOptions
-from ..tasks import remove_document_from_index
-from .factories import DocumentFactory
+from ..tasks import remove_publication_from_index
+from .factories import PublicationFactory
 
 
-class RemoveDocumentFromIndexTaskTests(VCRMixin, TestCase):
+class RemovePublicationFromIndexTaskTests(VCRMixin, TestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -29,29 +29,30 @@ class RemoveDocumentFromIndexTaskTests(VCRMixin, TestCase):
         config = GlobalConfiguration.get_solo()
         config.gpp_search_service = None
         config.save()
-        doc = DocumentFactory.create(publicatiestatus=PublicationStatusOptions.revoked)
+        publication = PublicationFactory.create(
+            publicatiestatus=PublicationStatusOptions.revoked
+        )
 
-        remote_task_id = remove_document_from_index(document_id=doc.pk)
+        remote_task_id = remove_publication_from_index(publication_id=publication.pk)
 
         self.assertIsNone(remote_task_id)
 
-    def test_index_skipped_for_published_document(self):
-        doc = DocumentFactory.create(
+    def test_remove_from_index_skipped_for_published_publication(self):
+        publication = PublicationFactory.create(
             publicatiestatus=PublicationStatusOptions.published
         )
 
-        remote_task_id = remove_document_from_index(document_id=doc.pk)
+        remote_task_id = remove_publication_from_index(publication_id=publication.pk)
 
         self.assertIsNone(remote_task_id)
 
-    def test_remove_revoked_document(self):
-        doc = DocumentFactory.create(
+    def test_remove_revoked_publication(self):
+        publication = PublicationFactory.create(
             uuid="1e4ed09f-c4d1-4eae-acf3-6b1378d8c05b",
             publicatiestatus=PublicationStatusOptions.revoked,
-            upload_complete=True,
         )
 
-        remote_task_id = remove_document_from_index(document_id=doc.pk)
+        remote_task_id = remove_publication_from_index(publication_id=publication.pk)
 
         self.assertIsNotNone(remote_task_id)
         self.assertIsInstance(remote_task_id, str)

--- a/src/woo_publications/publications/tests/vcr_cassettes/test_remove_document_from_index_task/RemoveDocumentFromIndexTaskTests/test_remove_by_uuid.yaml
+++ b/src/woo_publications/publications/tests/vcr_cassettes/test_remove_document_from_index_task/RemoveDocumentFromIndexTaskTests/test_remove_by_uuid.yaml
@@ -1,0 +1,40 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Token insecure-RySD8u5xkb9PH6AJtaZV4Y
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.32.3
+    method: DELETE
+    uri: http://localhost:8002/api/v1/documenten/fc8fc2db-829e-48d5-83b2-0a9364bfe717
+  response:
+    body:
+      string: '{"taskId":"28725ec7-5942-4705-ada9-909b17ebced8"}'
+    headers:
+      Allow:
+      - DELETE, OPTIONS
+      Content-Length:
+      - '49'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 202
+      message: Accepted
+version: 1

--- a/src/woo_publications/publications/tests/vcr_cassettes/test_remove_document_from_index_task/RemoveDocumentFromIndexTaskTests/test_remove_revoked_document.yaml
+++ b/src/woo_publications/publications/tests/vcr_cassettes/test_remove_document_from_index_task/RemoveDocumentFromIndexTaskTests/test_remove_revoked_document.yaml
@@ -1,0 +1,40 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Token insecure-RySD8u5xkb9PH6AJtaZV4Y
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.32.3
+    method: DELETE
+    uri: http://localhost:8002/api/v1/documenten/23dd6592-8b12-4296-b214-a98a5adf42ce
+  response:
+    body:
+      string: '{"taskId":"794a1c94-c0bd-432b-b050-d6e2df49054a"}'
+    headers:
+      Allow:
+      - DELETE, OPTIONS
+      Content-Length:
+      - '49'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 202
+      message: Accepted
+version: 1

--- a/src/woo_publications/publications/tests/vcr_cassettes/test_remove_publication_from_index_task/RemovePublicationFromIndexTaskTests/test_remove_by_uuid.yaml
+++ b/src/woo_publications/publications/tests/vcr_cassettes/test_remove_publication_from_index_task/RemovePublicationFromIndexTaskTests/test_remove_by_uuid.yaml
@@ -1,0 +1,40 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Token insecure-RySD8u5xkb9PH6AJtaZV4Y
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.32.3
+    method: DELETE
+    uri: http://localhost:8002/api/v1/publicaties/86b4df60-36d6-478e-8866-1293a5eac725
+  response:
+    body:
+      string: '{"taskId":"2e1200bf-ac41-476c-85c1-5f9d649b3e00"}'
+    headers:
+      Allow:
+      - DELETE, OPTIONS
+      Content-Length:
+      - '49'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 202
+      message: Accepted
+version: 1

--- a/src/woo_publications/publications/tests/vcr_cassettes/test_remove_publication_from_index_task/RemovePublicationFromIndexTaskTests/test_remove_revoked_publication.yaml
+++ b/src/woo_publications/publications/tests/vcr_cassettes/test_remove_publication_from_index_task/RemovePublicationFromIndexTaskTests/test_remove_revoked_publication.yaml
@@ -15,10 +15,10 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: DELETE
-    uri: http://localhost:8002/api/v1/documenten/1e4ed09f-c4d1-4eae-acf3-6b1378d8c05b
+    uri: http://localhost:8002/api/v1/publicaties/1e4ed09f-c4d1-4eae-acf3-6b1378d8c05b
   response:
     body:
-      string: '{"taskId":"cb8d254e-2b0b-4373-80ab-c0e9d01f4ceb"}'
+      string: '{"taskId":"ca1322dc-adfd-4d4b-8cd1-5b305a13f4e4"}'
     headers:
       Allow:
       - DELETE, OPTIONS


### PR DESCRIPTION
This ensures that API and admin operations remove documents/publications from the search index when they're no longer published, and adds some admin bulk actions to send/remove data to/from the search index.