### PR TITLE
Fixed broken oas link in api/index.rst

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -9,7 +9,7 @@ API Version            Date        View specification
 ====================== ==========  ==========================================
 ``latest``             n/a         `Redoc <https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/GPP-Woo/GPP-publicatiebank/main/src/woo_publications/api/openapi.yaml>`__,
                                    `Swagger <https://petstore.swagger.io/?url=https://raw.githubusercontent.com/GPP-Woo/GPP-publicatiebank/main/src/woo_publications/api/openapi.yaml>`__
-``1.0.0``              2024-12-12  `Redoc <https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/GPP-Woo/GPP-publicatiebank/1.0.0/src/woo_publications/api/openapi.yaml>`__,
+``1.0.0``              2024-12-12  `Redoc <https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/GPP-Woo/GPP-publicatiebank/1.0.0-rc.0/src/woo_publications/api/openapi.yaml>`__,
                                    `Swagger <https://petstore.swagger.io/?url=https://raw.githubusercontent.com/GPP-Woo/GPP-publicatiebank/1.0.0/src/woo_publications/api/openapi.yaml>`__
 ====================== ==========  ==========================================
 


### PR DESCRIPTION
**Changes**

changed version number to include the release candidate part of the url.

