### PR TITLE
Remove TODO from README

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -95,7 +95,7 @@ development machine.
 example file included in the same directory.
 
 
-Interaction with GPP Zoeken is done via Celery tasks. To run the workers, you need to
+Interaction with GPP-zoeken is done via Celery tasks. To run the workers, you need to
 have Redis (the message broker) running. Start the workers with:
 
 .. code-block:: bash

--- a/README.EN.rst
+++ b/README.EN.rst
@@ -32,7 +32,7 @@ publications, such as:
 * publications and associated documents
 * metadata models and expected shapes of metadata
 
-The component interfaces with a search index (TODO) and ensures the metadata and content
+The component interfaces with a GPP zoeken and ensures the metadata and content
 of documents is indexed, enabling the citizen portal to search through the publications.
 The data is provided in a format making it suitable to be indexed by the national
 crawler, by complying with the

--- a/README.EN.rst
+++ b/README.EN.rst
@@ -32,7 +32,7 @@ publications, such as:
 * publications and associated documents
 * metadata models and expected shapes of metadata
 
-The component interfaces with a GPP zoeken and ensures the metadata and content
+The component interfaces with a GPP-zoeken and ensures the metadata and content
 of documents is indexed, enabling the citizen portal to search through the publications.
 The data is provided in a format making it suitable to be indexed by the national
 crawler, by complying with the

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ een publicatie horen, zoals:
 * publicaties en bijhorende documenten
 * metamodellen/metagegevens
 
-Het component koppelt met de GPP zoeken en zorgt dat de metagegevens en inhoud van
+Het component koppelt met de GPP-zoeken en zorgt dat de metagegevens en inhoud van
 documenten geïndexeerd worden zodat het burgerportaal deze kan doorzoeken. De gegevens
 worden aangeboden in een formaat zodat deze aan de
 `Woo-Metadata-standaard <https://standaarden.overheid.nl/diwoo/metadata>`_ voldoen.

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ een publicatie horen, zoals:
 * publicaties en bijhorende documenten
 * metamodellen/metagegevens
 
-Het component koppelt met de zoekindex (TODO) en zorgt dat de metagegevens en inhoud van
+Het component koppelt met de GPP zoeken en zorgt dat de metagegevens en inhoud van
 documenten geïndexeerd worden zodat het burgerportaal deze kan doorzoeken. De gegevens
 worden aangeboden in een formaat zodat deze aan de
 `Woo-Metadata-standaard <https://standaarden.overheid.nl/diwoo/metadata>`_ voldoen.

--- a/docs/configuration/services.rst
+++ b/docs/configuration/services.rst
@@ -70,7 +70,7 @@ Configuration in the registration component
 GPP-Zoeken configuration
 ------------------------
 
-GPP-Publicatiebank depends on the `GPP Zoeken <https://gpp-zoeken.readthedocs.io/>`_
+GPP-Publicatiebank depends on the `GPP-zoeken <https://gpp-zoeken.readthedocs.io/>`_
 service to make publications available in the citizen portal. A service needs to be
 configured for this. If no service is configured, indexing operations will be skipped.
 

--- a/docs/developers/reference.rst
+++ b/docs/developers/reference.rst
@@ -35,11 +35,11 @@ Typically, we leverage Open Zaak for this (in development).
 
 Publication and document resources have a particular publication status - at the time of
 writing these are ``concept``, ``published`` and ``revoked``. Published resources are
-pushed to the GPP Zoeken API to be included in an Elastic Search index to power the
+pushed to the GPP-zoeken API to be included in an Elastic Search index to power the
 GPP Burgerportaal for search. When a resource is revoked, it is removed from the index
 again.
 
-Index operations (and by extension the interaction with GPP Zoeken) is done
+Index operations (and by extension the interaction with GPP-zoeken) is done
 asynchronously using Celery tasks, after the database transaction is committed.
 
 Database schema

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -94,20 +94,20 @@ uploads mechanism.
    1.4             Tested in CI (based on Open Zaak 1.16)
    ==============  ==========================
 
-GPP Zoeken
+GPP-zoeken
 **********
 
-GPP Zoeken manages the search index to facilitate full text and faceted search.
+GPP-zoeken manages the search index to facilitate full text and faceted search.
 
 .. seealso::
 
     See the :ref:`configuration <configuration_services>` docs.
 
-.. table:: GPP Zoeken API version support
+.. table:: GPP-zoeken API version support
    :widths: auto
 
    =============== ==========================
-   GPP Zoeken API  Status
+   GPP-zoeken API  Status
    =============== ==========================
    latest (dev)    Tested in CI
    =============== ==========================

--- a/src/woo_publications/contrib/tests/factories.py
+++ b/src/woo_publications/contrib/tests/factories.py
@@ -16,7 +16,7 @@ class ServiceFactory(_ServiceFactory):
             secret="insecure-yQL9Rzh4eHGVmYx5w3J2gu",
         )
         for_gpp_search_docker_compose = factory.Trait(
-            label="GPP Zoeken (docker-compose)",
+            label="GPP-zoeken (docker-compose)",
             api_root="http://localhost:8002/api/v1/",
             api_type=APITypes.orc,
             auth_type=AuthTypes.api_key,

--- a/src/woo_publications/publications/tasks.py
+++ b/src/woo_publications/publications/tasks.py
@@ -60,7 +60,7 @@ def index_document(*, document_id: int, download_url: str = "") -> str | None:
 @app.task
 def remove_document_from_index(*, document_id: int, force: bool = False) -> str | None:
     """
-    Remove the document from the GPP Zoeken index, if the status requires it.
+    Remove the document from the GPP-zoeken index, if the status requires it.
 
     If no service is configured or the document publication status is published, then
     the remove-from-index-operation is skipped.
@@ -121,7 +121,7 @@ def remove_publication_from_index(
     *, publication_id: int, force: bool = False
 ) -> str | None:
     """
-    Remove the publication from the GPP Zoeken index, if the status requires it.
+    Remove the publication from the GPP-zoeken index, if the status requires it.
 
     If no service is configured or the publication status is published, then
     the remove-from-index-operation is skipped.


### PR DESCRIPTION
Removed the TODO from the README.rst and README.EN.rst and changed the name of the external search component to `GPP zoeken`

Did a search and replace to `GPP Zoeken` -> `GPP zoeken`