### PR TITLE
Stream large file part uploads

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ omit =
     src/woo_publications/test_*
     src/woo_publications/utils/management/commands/clear_cache.py
     src/woo_publications/utils/migration_operations.py
+    src/woo_publications/utils/multipart_encoder.py  # vendored from requests-toolkit
 
 [coverage:report]
 skip_covered = True

--- a/src/woo_publications/publications/tests/vcr_cassettes/test_document_api_endpoints/DocumentApiCreateTests/test_upload_file_parts.yaml
+++ b/src/woo_publications/publications/tests/vcr_cassettes/test_document_api_endpoints/DocumentApiCreateTests/test_upload_file_parts.yaml
@@ -1,22 +1,22 @@
 interactions:
 - request:
-    body: '{"identificatie": "7f2334d4-8cd8-452f-94da-e828e3d27e93", "bronorganisatie":
+    body: '{"identificatie": "3d4f8db4-1fb4-484b-86c3-b55b69e4aa44", "bronorganisatie":
       "000000000", "informatieobjecttype": "http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/9aeb7501-3f77-4f36-8c8f-d21f47c2d6e8",
-      "creatiedatum": "2024-10-09", "titel": "activity", "auteur": "GPP-Woo/ODRC",
-      "status": "definitief", "formaat": "application/octet-stream", "taal": "dut",
-      "bestandsnaam": "unknown.bin", "inhoud": null, "bestandsomvang": 5, "beschrijving":
-      "", "indicatieGebruiksrecht": false}'
+      "creatiedatum": "2025-03-28", "titel": "cell", "auteur": "GPP-Woo/ODRC", "status":
+      "definitief", "formaat": "application/octet-stream", "taal": "dut", "bestandsnaam":
+      "unknown.bin", "inhoud": null, "bestandsomvang": 5, "beschrijving": "", "indicatieGebruiksrecht":
+      false}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTczMTA0ODg0MSwiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.Q8ESNMQ4VzNwOqisx8oG8HEIRoYSaTEpwJkS523iXHg
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTc0MzUyMTUzNCwiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.3NTvpq0GdiTGFvbRiEjPV6CmP9An8FMnrEwPDC5mpVA
       Connection:
       - keep-alive
       Content-Length:
-      - '500'
+      - '496'
       Content-Type:
       - application/json
       User-Agent:
@@ -25,24 +25,27 @@ interactions:
     uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten
   response:
     body:
-      string: '{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/848845a7-00eb-4d4d-ac7b-344153a6ec60","identificatie":"7f2334d4-8cd8-452f-94da-e828e3d27e93","bronorganisatie":"000000000","creatiedatum":"2024-10-09","titel":"activity","vertrouwelijkheidaanduiding":"openbaar","auteur":"GPP-Woo/ODRC","status":"definitief","formaat":"application/octet-stream","taal":"dut","versie":1,"beginRegistratie":"2024-11-08T06:54:02.069105Z","bestandsnaam":"unknown.bin","inhoud":null,"bestandsomvang":5,"link":"","beschrijving":"","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/9aeb7501-3f77-4f36-8c8f-d21f47c2d6e8","locked":true,"bestandsdelen":[{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/bestandsdelen/223ea6c9-e1e0-4c18-9790-53608158bad4","volgnummer":1,"omvang":5,"voltooid":false,"lock":"12206a12fc594741b7f011e0ae383bf4"}],"trefwoorden":[],"lock":"12206a12fc594741b7f011e0ae383bf4"}'
+      string: '{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/fdffc166-e09a-4a51-9b0e-0afeabc0a13a","identificatie":"3d4f8db4-1fb4-484b-86c3-b55b69e4aa44","bronorganisatie":"000000000","creatiedatum":"2025-03-28","titel":"cell","vertrouwelijkheidaanduiding":"openbaar","auteur":"GPP-Woo/ODRC","status":"definitief","formaat":"application/octet-stream","taal":"dut","versie":1,"beginRegistratie":"2025-04-01T15:32:14.502304Z","bestandsnaam":"unknown.bin","inhoud":null,"bestandsomvang":5,"link":"","beschrijving":"","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/9aeb7501-3f77-4f36-8c8f-d21f47c2d6e8","locked":true,"bestandsdelen":[{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/bestandsdelen/a9668f9b-f164-40f2-bfb6-4aa2fef01882","volgnummer":1,"omvang":5,"voltooid":false,"lock":"c73d0a81275142779a3aa490932be777"}],"trefwoorden":[],"lock":"c73d0a81275142779a3aa490932be777"}'
     headers:
       API-version:
       - 1.4.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1169'
+      - '1165'
       Content-Security-Policy:
-      - style-src 'self'; script-src 'self'; frame-src 'self'; base-uri 'self'; frame-ancestors
-        'none'; default-src 'self'; form-action 'self'; object-src 'none'; img-src
-        'self'
+      - 'worker-src ''self'' blob:; base-uri ''self''; object-src ''none''; frame-src
+        ''self''; img-src ''self'' data: cdn.redoc.ly cdnjs.cloudflare.com *.tile.openstreetmap.org;
+        connect-src ''self'' raw.githubusercontent.com; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com cdnjs.cloudflare.com;
+        form-action ''self''; default-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline'' cdnjs.cloudflare.com'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/848845a7-00eb-4d4d-ac7b-344153a6ec60
+      - http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/fdffc166-e09a-4a51-9b0e-0afeabc0a13a
       Referrer-Policy:
       - same-origin
       Vary:
@@ -55,28 +58,37 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: "--500603255f715edf30de06c84ca94520\r\nContent-Disposition: form-data; name=\"lock\"\r\n\r\n12206a12fc594741b7f011e0ae383bf4\r\n--500603255f715edf30de06c84ca94520\r\nContent-Disposition:
-      form-data; name=\"inhoud\"; filename=\"dummy.txt\"\r\n\r\naAaAa\r\n--500603255f715edf30de06c84ca94520--\r\n"
+    body: !!python/object/new:_io.BytesIO
+      state: !!python/tuple
+      - !!binary |
+        LS0wYzZhM2E4YzVjNWQ0NjhkODI3ZTAxYzdjMzc2MGE2Yw0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJsb2NrIg0KDQpjNzNkMGE4MTI3NTE0Mjc3OWEzYWE0OTA5MzJiZTc3
+        Nw0KLS0wYzZhM2E4YzVjNWQ0NjhkODI3ZTAxYzdjMzc2MGE2Yw0KQ29udGVudC1EaXNwb3NpdGlv
+        bjogZm9ybS1kYXRhOyBuYW1lPSJpbmhvdWQiOyBmaWxlbmFtZT0icGFydC5iaW4iDQpDb250ZW50
+        LVR5cGU6IGFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbQ0KDQphQWFBYQ0KLS0wYzZhM2E4YzVjNWQ0
+        NjhkODI3ZTAxYzdjMzc2MGE2Yy0tDQo=
+      - 0
+      - null
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTczMTA0ODg0MiwiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.Wgug0yxScI6R46lUObhSVLaNM-xJ4U3F9xHJGfvM2ck
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTc0MzUyMTUzNCwiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.3NTvpq0GdiTGFvbRiEjPV6CmP9An8FMnrEwPDC5mpVA
       Connection:
       - keep-alive
       Content-Length:
-      - '269'
+      - '308'
       Content-Type:
-      - multipart/form-data; boundary=500603255f715edf30de06c84ca94520
+      - multipart/form-data; boundary=0c6a3a8c5c5d468d827e01c7c3760a6c
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: http://openzaak.docker.internal:8001/documenten/api/v1/bestandsdelen/223ea6c9-e1e0-4c18-9790-53608158bad4
+    uri: http://openzaak.docker.internal:8001/documenten/api/v1/bestandsdelen/a9668f9b-f164-40f2-bfb6-4aa2fef01882
   response:
     body:
-      string: '{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/bestandsdelen/223ea6c9-e1e0-4c18-9790-53608158bad4","volgnummer":1,"omvang":5,"voltooid":true,"lock":"12206a12fc594741b7f011e0ae383bf4"}'
+      string: '{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/bestandsdelen/a9668f9b-f164-40f2-bfb6-4aa2fef01882","volgnummer":1,"omvang":5,"voltooid":true,"lock":"c73d0a81275142779a3aa490932be777"}'
     headers:
       API-version:
       - 1.4.2
@@ -85,9 +97,12 @@ interactions:
       Content-Length:
       - '199'
       Content-Security-Policy:
-      - style-src 'self'; script-src 'self'; frame-src 'self'; base-uri 'self'; frame-ancestors
-        'none'; default-src 'self'; form-action 'self'; object-src 'none'; img-src
-        'self'
+      - 'worker-src ''self'' blob:; base-uri ''self''; object-src ''none''; frame-src
+        ''self''; img-src ''self'' data: cdn.redoc.ly cdnjs.cloudflare.com *.tile.openstreetmap.org;
+        connect-src ''self'' raw.githubusercontent.com; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com cdnjs.cloudflare.com;
+        form-action ''self''; default-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline'' cdnjs.cloudflare.com'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -111,33 +126,36 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTczMTA0ODg0MiwiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.Wgug0yxScI6R46lUObhSVLaNM-xJ4U3F9xHJGfvM2ck
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTc0MzUyMTUzNCwiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.3NTvpq0GdiTGFvbRiEjPV6CmP9An8FMnrEwPDC5mpVA
       Connection:
       - keep-alive
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/848845a7-00eb-4d4d-ac7b-344153a6ec60
+    uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/fdffc166-e09a-4a51-9b0e-0afeabc0a13a
   response:
     body:
-      string: '{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/848845a7-00eb-4d4d-ac7b-344153a6ec60","identificatie":"7f2334d4-8cd8-452f-94da-e828e3d27e93","bronorganisatie":"000000000","creatiedatum":"2024-10-09","titel":"activity","vertrouwelijkheidaanduiding":"openbaar","auteur":"GPP-Woo/ODRC","status":"definitief","formaat":"application/octet-stream","taal":"dut","versie":1,"beginRegistratie":"2024-11-08T06:54:02.069105Z","bestandsnaam":"unknown.bin","inhoud":null,"bestandsomvang":5,"link":"","beschrijving":"","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/9aeb7501-3f77-4f36-8c8f-d21f47c2d6e8","locked":true,"bestandsdelen":[{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/bestandsdelen/223ea6c9-e1e0-4c18-9790-53608158bad4","volgnummer":1,"omvang":5,"voltooid":true,"lock":"12206a12fc594741b7f011e0ae383bf4"}],"trefwoorden":[]}'
+      string: '{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/fdffc166-e09a-4a51-9b0e-0afeabc0a13a","identificatie":"3d4f8db4-1fb4-484b-86c3-b55b69e4aa44","bronorganisatie":"000000000","creatiedatum":"2025-03-28","titel":"cell","vertrouwelijkheidaanduiding":"openbaar","auteur":"GPP-Woo/ODRC","status":"definitief","formaat":"application/octet-stream","taal":"dut","versie":1,"beginRegistratie":"2025-04-01T15:32:14.502304Z","bestandsnaam":"unknown.bin","inhoud":null,"bestandsomvang":5,"link":"","beschrijving":"","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/9aeb7501-3f77-4f36-8c8f-d21f47c2d6e8","locked":true,"bestandsdelen":[{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/bestandsdelen/a9668f9b-f164-40f2-bfb6-4aa2fef01882","volgnummer":1,"omvang":5,"voltooid":true,"lock":"c73d0a81275142779a3aa490932be777"}],"trefwoorden":[]}'
     headers:
       API-version:
       - 1.4.2
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       Content-Length:
-      - '1126'
+      - '1122'
       Content-Security-Policy:
-      - style-src 'self'; script-src 'self'; frame-src 'self'; base-uri 'self'; frame-ancestors
-        'none'; default-src 'self'; form-action 'self'; object-src 'none'; img-src
-        'self'
+      - 'worker-src ''self'' blob:; base-uri ''self''; object-src ''none''; frame-src
+        ''self''; img-src ''self'' data: cdn.redoc.ly cdnjs.cloudflare.com *.tile.openstreetmap.org;
+        connect-src ''self'' raw.githubusercontent.com; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com cdnjs.cloudflare.com;
+        form-action ''self''; default-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline'' cdnjs.cloudflare.com'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       ETag:
-      - '"d140cc5691883a0cc4bb47a144451d5d"'
+      - '"a132235c66ccbbdc7afe22602e28cdb0"'
       Referrer-Policy:
       - same-origin
       Vary:
@@ -150,14 +168,14 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"lock": "12206a12fc594741b7f011e0ae383bf4"}'
+    body: '{"lock": "c73d0a81275142779a3aa490932be777"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTczMTA0ODg0MiwiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.Wgug0yxScI6R46lUObhSVLaNM-xJ4U3F9xHJGfvM2ck
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTc0MzUyMTUzNCwiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.3NTvpq0GdiTGFvbRiEjPV6CmP9An8FMnrEwPDC5mpVA
       Connection:
       - keep-alive
       Content-Length:
@@ -167,7 +185,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/848845a7-00eb-4d4d-ac7b-344153a6ec60/unlock
+    uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/fdffc166-e09a-4a51-9b0e-0afeabc0a13a/unlock
   response:
     body:
       string: ''
@@ -179,9 +197,12 @@ interactions:
       Content-Length:
       - '0'
       Content-Security-Policy:
-      - style-src 'self'; script-src 'self'; frame-src 'self'; base-uri 'self'; frame-ancestors
-        'none'; default-src 'self'; form-action 'self'; object-src 'none'; img-src
-        'self'
+      - 'worker-src ''self'' blob:; base-uri ''self''; object-src ''none''; frame-src
+        ''self''; img-src ''self'' data: cdn.redoc.ly cdnjs.cloudflare.com *.tile.openstreetmap.org;
+        connect-src ''self'' raw.githubusercontent.com; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com cdnjs.cloudflare.com;
+        form-action ''self''; default-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline'' cdnjs.cloudflare.com'
       Cross-Origin-Opener-Policy:
       - same-origin
       Referrer-Policy:
@@ -203,33 +224,36 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTczMTA0ODg0MiwiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.Wgug0yxScI6R46lUObhSVLaNM-xJ4U3F9xHJGfvM2ck
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTc0MzUyMTUzNCwiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.3NTvpq0GdiTGFvbRiEjPV6CmP9An8FMnrEwPDC5mpVA
       Connection:
       - keep-alive
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/848845a7-00eb-4d4d-ac7b-344153a6ec60
+    uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/fdffc166-e09a-4a51-9b0e-0afeabc0a13a
   response:
     body:
-      string: '{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/848845a7-00eb-4d4d-ac7b-344153a6ec60","identificatie":"7f2334d4-8cd8-452f-94da-e828e3d27e93","bronorganisatie":"000000000","creatiedatum":"2024-10-09","titel":"activity","vertrouwelijkheidaanduiding":"openbaar","auteur":"GPP-Woo/ODRC","status":"definitief","formaat":"application/octet-stream","taal":"dut","versie":1,"beginRegistratie":"2024-11-08T06:54:02.273858Z","bestandsnaam":"unknown.bin","inhoud":"http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/848845a7-00eb-4d4d-ac7b-344153a6ec60/download?versie=1","bestandsomvang":5,"link":"","beschrijving":"","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/9aeb7501-3f77-4f36-8c8f-d21f47c2d6e8","locked":false,"bestandsdelen":[],"trefwoorden":[]}'
+      string: '{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/fdffc166-e09a-4a51-9b0e-0afeabc0a13a","identificatie":"3d4f8db4-1fb4-484b-86c3-b55b69e4aa44","bronorganisatie":"000000000","creatiedatum":"2025-03-28","titel":"cell","vertrouwelijkheidaanduiding":"openbaar","auteur":"GPP-Woo/ODRC","status":"definitief","formaat":"application/octet-stream","taal":"dut","versie":1,"beginRegistratie":"2025-04-01T15:32:14.732258Z","bestandsnaam":"unknown.bin","inhoud":"http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/fdffc166-e09a-4a51-9b0e-0afeabc0a13a/download?versie=1","bestandsomvang":5,"link":"","beschrijving":"","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/9aeb7501-3f77-4f36-8c8f-d21f47c2d6e8","locked":false,"bestandsdelen":[],"trefwoorden":[]}'
     headers:
       API-version:
       - 1.4.2
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       Content-Length:
-      - '1065'
+      - '1061'
       Content-Security-Policy:
-      - style-src 'self'; script-src 'self'; frame-src 'self'; base-uri 'self'; frame-ancestors
-        'none'; default-src 'self'; form-action 'self'; object-src 'none'; img-src
-        'self'
+      - 'worker-src ''self'' blob:; base-uri ''self''; object-src ''none''; frame-src
+        ''self''; img-src ''self'' data: cdn.redoc.ly cdnjs.cloudflare.com *.tile.openstreetmap.org;
+        connect-src ''self'' raw.githubusercontent.com; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com cdnjs.cloudflare.com;
+        form-action ''self''; default-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline'' cdnjs.cloudflare.com'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       ETag:
-      - '"d140cc5691883a0cc4bb47a144451d5d"'
+      - '"a132235c66ccbbdc7afe22602e28cdb0"'
       Referrer-Policy:
       - same-origin
       Vary:
@@ -249,13 +273,13 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTczMTA0ODg0MiwiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.Wgug0yxScI6R46lUObhSVLaNM-xJ4U3F9xHJGfvM2ck
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTc0MzUyMTUzNCwiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.3NTvpq0GdiTGFvbRiEjPV6CmP9An8FMnrEwPDC5mpVA
       Connection:
       - keep-alive
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/848845a7-00eb-4d4d-ac7b-344153a6ec60/download
+    uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/fdffc166-e09a-4a51-9b0e-0afeabc0a13a/download
   response:
     body:
       string: aAaAa
@@ -263,11 +287,14 @@ interactions:
       Allow:
       - GET, HEAD, OPTIONS
       Content-Disposition:
-      - attachment; filename="unknown_exuFg4M.bin"
+      - attachment; filename="unknown_ryRH2gL.bin"
       Content-Security-Policy:
-      - style-src 'self'; script-src 'self'; frame-src 'self'; base-uri 'self'; frame-ancestors
-        'none'; default-src 'self'; form-action 'self'; object-src 'none'; img-src
-        'self'
+      - 'worker-src ''self'' blob:; base-uri ''self''; object-src ''none''; frame-src
+        ''self''; img-src ''self'' data: cdn.redoc.ly cdnjs.cloudflare.com *.tile.openstreetmap.org;
+        connect-src ''self'' raw.githubusercontent.com; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com cdnjs.cloudflare.com;
+        form-action ''self''; default-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline'' cdnjs.cloudflare.com'
       Content-Type:
       - application/octet-stream
       Content-length:
@@ -275,7 +302,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Last-Modified:
-      - Fri, 08 Nov 2024 06:54:02 GMT
+      - Tue, 01 Apr 2025 15:32:14 GMT
       Referrer-Policy:
       - same-origin
       Vary:

--- a/src/woo_publications/utils/multipart_encoder.py
+++ b/src/woo_publications/utils/multipart_encoder.py
@@ -1,0 +1,501 @@
+# SPDX-FileCopyrightText: Copyright 2014 Ian Cordasco, Cory Benfield
+# SPDX-License-Identifier:  Apache-2.0
+#
+# The code in this module was taken from requests-toolbelt:
+# https://github.com/requests/toolbelt/blob/bcd5f7be229e14089052be7e3b527ebcea0ae7b8/requests_toolbelt/multipart/encoder.py
+
+"""
+Copyright 2014 Ian Cordasco, Cory Benfield
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+import contextlib
+import io
+import os
+from typing import assert_never
+from uuid import uuid4
+
+from urllib3 import fields
+
+
+class FileNotSupportedError(Exception):
+    """File not supported error."""
+
+
+class MultipartEncoder(object):
+    """
+
+    The ``MultipartEncoder`` object is a generic interface to the engine that
+    will create a ``multipart/form-data`` body for you.
+
+    The basic usage is:
+
+    .. code-block:: python
+
+        import requests
+        from requests_toolbelt import MultipartEncoder
+
+        encoder = MultipartEncoder({'field': 'value',
+                                    'other_field': 'other_value'})
+        r = requests.post('https://httpbin.org/post', data=encoder,
+                          headers={'Content-Type': encoder.content_type})
+
+    If you do not need to take advantage of streaming the post body, you can
+    also do:
+
+    .. code-block:: python
+
+        r = requests.post('https://httpbin.org/post',
+                          data=encoder.to_string(),
+                          headers={'Content-Type': encoder.content_type})
+
+    If you want the encoder to use a specific order, you can use an
+    OrderedDict or more simply, a list of tuples:
+
+    .. code-block:: python
+
+        encoder = MultipartEncoder([('field', 'value'),
+                                    ('other_field', 'other_value')])
+
+    .. versionchanged:: 0.4.0
+
+    You can also provide tuples as part values as you would provide them to
+    requests' ``files`` parameter.
+
+    .. code-block:: python
+
+        encoder = MultipartEncoder({
+            'field': ('file_name', b'{"a": "b"}', 'application/json',
+                      {'X-My-Header': 'my-value'})
+        ])
+
+    .. warning::
+
+        This object will end up directly in :mod:`httplib`. Currently,
+        :mod:`httplib` has a hard-coded read size of **8192 bytes**. This
+        means that it will loop until the file has been read and your upload
+        could take a while. This is **not** a bug in requests. A feature is
+        being considered for this object to allow you, the user, to specify
+        what size should be returned on a read. If you have opinions on this,
+        please weigh in on `this issue`_.
+
+    .. _this issue:
+        https://github.com/requests/toolbelt/issues/75
+
+    """
+
+    def __init__(self, fields, boundary=None, encoding="utf-8"):
+        #: Boundary value either passed in by the user or created
+        self.boundary_value = boundary or uuid4().hex
+
+        # Computed boundary
+        self.boundary = "--{}".format(self.boundary_value)
+
+        #: Encoding of the data being passed in
+        self.encoding = encoding
+
+        # Pre-encoded boundary
+        self._encoded_boundary = b"".join(
+            [
+                encode_with(self.boundary, self.encoding),
+                encode_with("\r\n", self.encoding),
+            ]
+        )
+
+        #: Fields provided by the user
+        self.fields = fields
+
+        #: Whether or not the encoder is finished
+        self.finished = False
+
+        #: Pre-computed parts of the upload
+        self.parts = []
+
+        # Pre-computed parts iterator
+        self._iter_parts = iter([])
+
+        # The part we're currently working with
+        self._current_part = None
+
+        # Cached computation of the body's length
+        self._len = None
+
+        # Our buffer
+        self._buffer = CustomBytesIO(encoding=encoding)
+
+        # Pre-compute each part's headers
+        self._prepare_parts()
+
+        # Load boundary into buffer
+        self._write_boundary()
+
+    @property
+    def len(self):
+        """Length of the multipart/form-data body.
+
+        requests will first attempt to get the length of the body by calling
+        ``len(body)`` and then by checking for the ``len`` attribute.
+
+        On 32-bit systems, the ``__len__`` method cannot return anything
+        larger than an integer (in C) can hold. If the total size of the body
+        is even slightly larger than 4GB users will see an OverflowError. This
+        manifested itself in `bug #80`_.
+
+        As such, we now calculate the length lazily as a property.
+
+        .. _bug #80:
+            https://github.com/requests/toolbelt/issues/80
+        """
+        # If _len isn't already calculated, calculate, return, and set it
+        return self._len or self._calculate_length()
+
+    def __repr__(self):
+        return "<MultipartEncoder: {!r}>".format(self.fields)
+
+    def _calculate_length(self):
+        """
+        This uses the parts to calculate the length of the body.
+
+        This returns the calculated length so __len__ can be lazy.
+        """
+        boundary_len = len(self.boundary)  # Length of --{boundary}
+        # boundary length + header length + body length + len('\r\n') * 2
+        self._len = (
+            sum((boundary_len + total_len(p) + 4) for p in self.parts)
+            + boundary_len
+            + 4
+        )
+        return self._len
+
+    def _calculate_load_amount(self, read_size):
+        """This calculates how many bytes need to be added to the buffer.
+
+        When a consumer read's ``x`` from the buffer, there are two cases to
+        satisfy:
+
+            1. Enough data in the buffer to return the requested amount
+            2. Not enough data
+
+        This function uses the amount of unread bytes in the buffer and
+        determines how much the Encoder has to load before it can return the
+        requested amount of bytes.
+
+        :param int read_size: the number of bytes the consumer requests
+        :returns: int -- the number of bytes that must be loaded into the
+            buffer before the read can be satisfied. This will be strictly
+            non-negative
+        """
+        amount = read_size - total_len(self._buffer)
+        return amount if amount > 0 else 0
+
+    def _load(self, amount):
+        """Load ``amount`` number of bytes into the buffer."""
+        self._buffer.smart_truncate()
+        part = self._current_part or self._next_part()
+        while amount == -1 or amount > 0:
+            written = 0
+            if part and not part.bytes_left_to_write():
+                written += self._write(b"\r\n")
+                written += self._write_boundary()
+                part = self._next_part()
+
+            if not part:
+                written += self._write_closing_boundary()
+                self.finished = True
+                break
+
+            written += part.write_to(self._buffer, amount)
+
+            if amount != -1:
+                amount -= written
+
+    def _next_part(self):
+        try:
+            p = self._current_part = next(self._iter_parts)
+        except StopIteration:
+            p = None
+        return p
+
+    def _iter_fields(self):
+        _fields = self.fields
+        if hasattr(self.fields, "items"):
+            _fields = list(self.fields.items())
+        for k, v in _fields:
+            file_name = None
+            file_type = None
+            file_headers = None
+            if isinstance(v, (list, tuple)):
+                if len(v) == 2:
+                    file_name, file_pointer = v
+                elif len(v) == 3:
+                    file_name, file_pointer, file_type = v
+                else:
+                    file_name, file_pointer, file_type, file_headers = v
+            else:
+                file_pointer = v
+
+            field = fields.RequestField(
+                name=k, data=file_pointer, filename=file_name, headers=file_headers
+            )
+            field.make_multipart(content_type=file_type)
+            yield field
+
+    def _prepare_parts(self):
+        """This uses the fields provided by the user and creates Part objects.
+
+        It populates the `parts` attribute and uses that to create a
+        generator for iteration.
+        """
+        enc = self.encoding
+        self.parts = [Part.from_field(f, enc) for f in self._iter_fields()]
+        self._iter_parts = iter(self.parts)
+
+    def _write(self, bytes_to_write):
+        """Write the bytes to the end of the buffer.
+
+        :param bytes bytes_to_write: byte-string (or bytearray) to append to
+            the buffer
+        :returns: int -- the number of bytes written
+        """
+        return self._buffer.append(bytes_to_write)
+
+    def _write_boundary(self):
+        """Write the boundary to the end of the buffer."""
+        return self._write(self._encoded_boundary)
+
+    def _write_closing_boundary(self):
+        """Write the bytes necessary to finish a multipart/form-data body."""
+        with reset(self._buffer):
+            self._buffer.seek(-2, 2)
+            self._buffer.write(b"--\r\n")
+        return 2
+
+    def _write_headers(self, headers):
+        """Write the current part's headers to the buffer."""
+        return self._write(encode_with(headers, self.encoding))
+
+    @property
+    def content_type(self):
+        return str("multipart/form-data; boundary={}".format(self.boundary_value))
+
+    def to_string(self):
+        """Return the entirety of the data in the encoder.
+
+        .. note::
+
+            This simply reads all of the data it can. If you have started
+            streaming or reading data from the encoder, this method will only
+            return whatever data is left in the encoder.
+
+        .. note::
+
+            This method affects the internal state of the encoder. Calling
+            this method will exhaust the encoder.
+
+        :returns: the multipart message
+        :rtype: bytes
+        """
+
+        return self.read()
+
+    def read(self, size=-1):
+        """Read data from the streaming encoder.
+
+        :param int size: (optional), If provided, ``read`` will return exactly
+            that many bytes. If it is not provided, it will return the
+            remaining bytes.
+        :returns: bytes
+        """
+        if self.finished:
+            return self._buffer.read(size)
+
+        bytes_to_load = size
+        if bytes_to_load != -1 and bytes_to_load is not None:
+            bytes_to_load = self._calculate_load_amount(int(size))
+
+        self._load(bytes_to_load)
+        return self._buffer.read(size)
+
+
+def encode_with(string, encoding):
+    """Encoding ``string`` with ``encoding`` if necessary.
+
+    :param str string: If string is a bytes object, it will not encode it.
+        Otherwise, this function will encode it with the provided encoding.
+    :param str encoding: The encoding with which to encode string.
+    :returns: encoded bytes object
+    """
+    if not (string is None or isinstance(string, bytes)):
+        return string.encode(encoding)
+    return string
+
+
+def readable_data(data, encoding):
+    """Coerce the data to an object with a ``read`` method."""
+    if hasattr(data, "read"):
+        return data
+
+    return CustomBytesIO(data, encoding)
+
+
+def total_len(o):
+    if hasattr(o, "__len__"):
+        return len(o)
+
+    if hasattr(o, "len"):
+        return o.len
+
+    if hasattr(o, "fileno"):
+        try:
+            fileno = o.fileno()
+        except io.UnsupportedOperation:
+            pass
+        else:
+            return os.fstat(fileno).st_size
+
+    if hasattr(o, "getvalue"):
+        # e.g. BytesIO, cStringIO.StringIO
+        return len(o.getvalue())
+
+    assert_never(o)
+
+
+@contextlib.contextmanager
+def reset(buffer):
+    """Keep track of the buffer's current position and write to the end.
+
+    This is a context manager meant to be used when adding data to the buffer.
+    It eliminates the need for every function to be concerned with the
+    position of the cursor in the buffer.
+    """
+    original_position = buffer.tell()
+    buffer.seek(0, 2)
+    yield
+    buffer.seek(original_position, 0)
+
+
+def coerce_data(data, encoding):
+    """Ensure that every object's __len__ behaves uniformly."""
+    if not isinstance(data, CustomBytesIO):
+        if hasattr(data, "getvalue"):
+            return CustomBytesIO(data.getvalue(), encoding)
+
+        if hasattr(data, "fileno"):
+            return FileWrapper(data)
+
+        if not hasattr(data, "read"):
+            return CustomBytesIO(data, encoding)
+
+    return data
+
+
+def to_list(fields):
+    if hasattr(fields, "items"):
+        return list(fields.items())
+    return list(fields)
+
+
+class Part(object):
+    def __init__(self, headers, body):
+        self.headers = headers
+        self.body = body
+        self.headers_unread = True
+        self.len = len(self.headers) + total_len(self.body)
+
+    @classmethod
+    def from_field(cls, field, encoding):
+        """Create a part from a Request Field generated by urllib3."""
+        headers = encode_with(field.render_headers(), encoding)
+        body = coerce_data(field.data, encoding)
+        return cls(headers, body)
+
+    def bytes_left_to_write(self):
+        """Determine if there are bytes left to write.
+
+        :returns: bool -- ``True`` if there are bytes left to write, otherwise
+            ``False``
+        """
+        to_read = 0
+        if self.headers_unread:
+            to_read += len(self.headers)
+
+        return (to_read + total_len(self.body)) > 0
+
+    def write_to(self, buffer, size):
+        """Write the requested amount of bytes to the buffer provided.
+
+        The number of bytes written may exceed size on the first read since we
+        load the headers ambitiously.
+
+        :param CustomBytesIO buffer: buffer we want to write bytes to
+        :param int size: number of bytes requested to be written to the buffer
+        :returns: int -- number of bytes actually written
+        """
+        written = 0
+        if self.headers_unread:
+            written += buffer.append(self.headers)
+            self.headers_unread = False
+
+        while total_len(self.body) > 0 and (size == -1 or written < size):
+            amount_to_read = size
+            if size != -1:
+                amount_to_read = size - written
+            written += buffer.append(self.body.read(amount_to_read))
+
+        return written
+
+
+class CustomBytesIO(io.BytesIO):
+    def __init__(self, buffer=None, encoding="utf-8"):
+        buffer = encode_with(buffer, encoding)
+        super(CustomBytesIO, self).__init__(buffer)  # type: ignore
+
+    def _get_end(self):
+        current_pos = self.tell()
+        self.seek(0, 2)
+        length = self.tell()
+        self.seek(current_pos, 0)
+        return length
+
+    @property
+    def len(self):
+        length = self._get_end()
+        return length - self.tell()
+
+    def append(self, bytes):
+        with reset(self):
+            written = self.write(bytes)
+        return written
+
+    def smart_truncate(self):
+        to_be_read = total_len(self)
+        already_read = self._get_end() - to_be_read
+
+        if already_read >= to_be_read:
+            old_bytes = self.read()
+            self.seek(0, 0)
+            self.truncate()
+            self.write(old_bytes)
+            self.seek(0, 0)  # We want to be at the beginning
+
+
+class FileWrapper(object):
+    def __init__(self, file_object):
+        self.fd = file_object
+
+    @property
+    def len(self):
+        return total_len(self.fd) - self.fd.tell()
+
+    def read(self, length=-1):
+        return self.fd.read(length)


### PR DESCRIPTION
Fixes #232 

**Changes**

* Leveraged multipart encoder from requests-toolkit to stream large files so we don't have to load them into memory.

The chunks are read 16MB at a time, via urllib3's default configuration. I haven't checked if we can override this, but I assume the
defaults are okay for now.

