### PR TITLE
Revoke admin action

### DIFF
--- a/docs/admin/publicaties/index.rst
+++ b/docs/admin/publicaties/index.rst
@@ -22,7 +22,7 @@ Op dit scherm zijn de volgende acties mogelijk:
 * Rechtboven zit een knop **document toevoegen** waarmee een registratie toegevoegd kan worden.
 * Bovenaan zit een zoekveld met een knop **Zoeken** waarmee in de registraties gezocht kan worden.
 * Direct onder de zoekbalk zit de mogelijkheid om de lijst te **filteren op een specifieke registratiedatum**.
-* Daaronder zit de mogelijkheid om **eenzelfde actie uit te voeren over meerdere documentregistraties**. Op dit moment worden de acties **Geselecteerde documenten verwijderen**, **Verstuur de geselecteerde documenten naar de zoekindex** en **Verwijder de geselecteerde documenten uit de zoekindex** ondersteund. Merk op dat het mogelijk is om in de lijst één of meerdere *document*-registraties aan te vinken.
+* Daaronder zit de mogelijkheid om **eenzelfde actie uit te voeren over meerdere documentregistraties**. Op dit moment worden de acties **Geselecteerde documenten verwijderen**, **Verstuur de geselecteerde documenten naar de zoekindex**, **Verwijder de geselecteerde documenten uit de zoekindex** en **Trek gepubliceerde documenten in** ondersteund. Merk op dat het mogelijk is om in de lijst één of meerdere *document*-registraties aan te vinken.
 * Onder de (bulk-)actie staat de lijst met *document*-registraties. Door op de kolomtitels te klikken kan de lijst **alfabetisch of chronologisch geordend** worden.
 * Rechts naast de lijst bestaat de mogelijkheid om deze te **filteren op registratiedatum, creatiedatum en/of publicatiestatus**.
 * Bij een *document*-registratie kan op de `officiële titel` geklikt worden om **de details in te zien** en deze eventueel **te wijzigen**.
@@ -95,7 +95,7 @@ Op dit scherm zijn de volgende acties mogelijk:
 * Rechtboven zit een knop **publicatie toevoegen** waarmee een registratie toegevoegd kan worden.
 * Bovenaan zit een zoekveld met een knop **Zoeken** waarmee in de registraties gezocht kan worden.
 * Direct onder de zoekbalk zit de mogelijkheid om de lijst te **filteren op een specifieke registratiedatum**.
-* Daaronder zit de mogelijkheid om **eenzelfde actie uit te voeren over meerdere publicaties**. Op dit moment worden de acties **Geselecteerde publicaties verwijderen**, **Verstuur de geselecteerde publicaties naar de zoekindex**, **Verwijder de geselecteerde publicaties uit de zoekindex** en **Geselecteerde publicaties herwaarderen** ondersteund. Merk op dat het mogelijk is om in de lijst één of meerdere *publicatie*-registraties aan te vinken.
+* Daaronder zit de mogelijkheid om **eenzelfde actie uit te voeren over meerdere publicaties**. Op dit moment worden de acties **Geselecteerde publicaties verwijderen**, **Verstuur de geselecteerde publicaties naar de zoekindex**, **Verwijder de geselecteerde publicaties uit de zoekindex**, **Trek gepubliceerde publicaties in** en **Geselecteerde publicaties herwaarderen** ondersteund. Merk op dat het mogelijk is om in de lijst één of meerdere *publicatie*-registraties aan te vinken.
 * Onder de (bulk-)actie staat de lijst met *publicatie*-registraties. Door op de kolomtitels te klikken kan de lijst **alfabetisch of chronologisch geordend** worden.
 * Rechts naast de lijst bestaat de mogelijkheid om deze te **filteren op registratiedatum en/of publicatiestatus**.
 * Bij een *publicatie*-registratie kan op de `officiële titel` geklikt worden om **de details in te zien** en deze eventueel **te wijzigen**.
@@ -165,7 +165,7 @@ Op dit scherm zijn de volgende acties mogelijk:
 * Rechtsboven zit een knop **onderwerp toevoegen** waarmee een registratie toegevoegd kan worden.
 * Bovenaan zit een zoekveld met een knop **Zoeken** waarmee in de registraties gezocht kan worden.
 * Direct onder de zoekbalk zit de mogelijkheid om de lijst te **filteren op een specifieke registratiedatum**.
-* Daaronder zit de mogelijkheid om **eenzelfde actie uit te voeren over meerdere onderwerpen**. Op dit moment wordt alleen de actie **Geselecteerde onderwerpen verwijderen** ondersteund. Merk op dat het mogelijk is om in de lijst één of meerdere *onderwerp*-registraties aan te vinken.
+* Daaronder zit de mogelijkheid om **eenzelfde actie uit te voeren over meerdere onderwerpen**. Op dit moment wordt alleen de actie **Geselecteerde onderwerpen verwijderen** en **Trek gepubliceerde onderwerpen in** ondersteund. Merk op dat het mogelijk is om in de lijst één of meerdere *onderwerp*-registraties aan te vinken.
 * Onder de (bulk-)actie staat de lijst met *onderwerp*-registraties. Door op de kolomtitels te klikken kan de lijst **alfabetisch of chronologisch geordend** worden.
 * Rechts naast de lijst bestaat de mogelijkheid om deze te **filteren op registratiedatum, publicatiestatus, archiefnominatie en/of archiefdatum**.
 * Bij een *onderwerp*-registratie kan op de `officiële titel` geklikt worden om **de details in te zien** en deze eventueel **te wijzigen**.

--- a/src/woo_publications/publications/admin.py
+++ b/src/woo_publications/publications/admin.py
@@ -159,12 +159,16 @@ def reassess_retention_policy(
 
 
 @admin.action(description=_("revoke the selected %(verbose_name_plural)s"))
-def revoke_instance(
+def revoke(
     modeladmin: PublicationAdmin | DocumentAdmin | TopicAdmin,
     request: HttpRequest,
     queryset: models.QuerySet[Publication | Document | Topic],
 ):
     assert is_authenticated_request(request)
+    queryset = queryset.filter(
+        ~models.Q(publicatiestatus=PublicationStatusOptions.revoked)
+    )
+
     model = queryset.model
     num_objects = queryset.count()
 
@@ -298,7 +302,7 @@ class PublicationAdmin(AdminAuditLogMixin, admin.ModelAdmin):
         sync_to_index,
         remove_from_index,
         reassess_retention_policy,
-        revoke_instance,
+        revoke,
     ]
 
     def has_change_permission(self, request, obj=None):
@@ -518,7 +522,7 @@ class DocumentAdmin(AdminAuditLogMixin, admin.ModelAdmin):
         "publicatiestatus",
     )
     date_hierarchy = "registratiedatum"
-    actions = [sync_to_index, remove_from_index, revoke_instance]
+    actions = [sync_to_index, remove_from_index, revoke]
 
     def save_model(
         self, request: HttpRequest, obj: Document, form: forms.Form, change: bool
@@ -639,7 +643,7 @@ class TopicAdmin(AdminAuditLogMixin, admin.ModelAdmin):
     )
     inlines = (PublicationInline,)
     date_hierarchy = "registratiedatum"
-    actions = [sync_to_index, remove_from_index, revoke_instance]
+    actions = [sync_to_index, remove_from_index, revoke]
 
     def save_model(
         self, request: HttpRequest, obj: Topic, form: forms.Form, change: bool

--- a/src/woo_publications/publications/admin.py
+++ b/src/woo_publications/publications/admin.py
@@ -17,6 +17,8 @@ from django.utils.translation import gettext_lazy as _, ngettext
 
 from furl import furl
 
+from woo_publications.logging.logevent import audit_admin_update
+from woo_publications.logging.serializing import serialize_instance
 from woo_publications.logging.service import AdminAuditLogMixin, get_logs_link
 from woo_publications.metadata.models import Organisation
 from woo_publications.typing import is_authenticated_request
@@ -156,6 +158,60 @@ def reassess_retention_policy(
     )
 
 
+@admin.action(description=_("revoke the selected %(verbose_name_plural)s"))
+def revoke_instance(
+    modeladmin: PublicationAdmin | DocumentAdmin | TopicAdmin,
+    request: HttpRequest,
+    queryset: models.QuerySet[Publication | Document | Topic],
+):
+    assert is_authenticated_request(request)
+    model = queryset.model
+    num_objects = queryset.count()
+
+    if model is Publication:
+        task_fn = remove_publication_from_index
+        kwarg_name = "publication_id"
+    elif model is Document:
+        task_fn = remove_document_from_index
+        kwarg_name = "document_id"
+    elif model is Topic:
+        task_fn = remove_topic_from_index
+        kwarg_name = "topic_id"
+    else:  # pragma: no cover
+        raise ValueError("Unsupported model: %r", model)
+
+    for obj in queryset.iterator():
+        obj.publicatiestatus = PublicationStatusOptions.revoked
+        obj.save()
+
+        audit_admin_update(
+            content_object=obj,
+            object_data=serialize_instance(obj),
+            django_user=request.user,
+        )
+
+        transaction.on_commit(
+            partial(task_fn.delay, force=True, **{kwarg_name: obj.pk})
+        )
+
+        if model is Publication:
+            assert isinstance(obj, Publication)
+            obj.revoke_own_published_documents(request.user)
+
+    modeladmin.message_user(
+        request,
+        ngettext(
+            "{count} {verbose_name} object revoked.",
+            "{count} {verbose_name} objects revoked.",
+            num_objects,
+        ).format(
+            count=num_objects,
+            verbose_name=model._meta.verbose_name,
+        ),
+        messages.SUCCESS,
+    )
+
+
 class DocumentInlineAdmin(admin.StackedInline):
     formset = DocumentAuditLogInlineformset
     model = Document
@@ -238,7 +294,12 @@ class PublicationAdmin(AdminAuditLogMixin, admin.ModelAdmin):
     )
     date_hierarchy = "registratiedatum"
     inlines = (DocumentInlineAdmin,)
-    actions = [sync_to_index, remove_from_index, reassess_retention_policy]
+    actions = [
+        sync_to_index,
+        remove_from_index,
+        reassess_retention_policy,
+        revoke_instance,
+    ]
 
     def has_change_permission(self, request, obj=None):
         if obj and obj.publicatiestatus == PublicationStatusOptions.revoked:
@@ -457,7 +518,7 @@ class DocumentAdmin(AdminAuditLogMixin, admin.ModelAdmin):
         "publicatiestatus",
     )
     date_hierarchy = "registratiedatum"
-    actions = [sync_to_index, remove_from_index]
+    actions = [sync_to_index, remove_from_index, revoke_instance]
 
     def save_model(
         self, request: HttpRequest, obj: Document, form: forms.Form, change: bool
@@ -578,7 +639,7 @@ class TopicAdmin(AdminAuditLogMixin, admin.ModelAdmin):
     )
     inlines = (PublicationInline,)
     date_hierarchy = "registratiedatum"
-    actions = [sync_to_index, remove_from_index]
+    actions = [sync_to_index, remove_from_index, revoke_instance]
 
     def save_model(
         self, request: HttpRequest, obj: Topic, form: forms.Form, change: bool

--- a/src/woo_publications/publications/tests/test_admin_logging.py
+++ b/src/woo_publications/publications/tests/test_admin_logging.py
@@ -359,7 +359,7 @@ class TestPublicationAdminAuditLogging(WebTest):
 
             self.assertEqual(update_publication_log.extra_data, expected_data)
 
-    def test_publication_revoke_instance_action_log(self):
+    def test_publication_revoke_action_log(self):
         assert not TimelineLogProxy.objects.exists()
         ic, ic2 = InformationCategoryFactory.create_batch(2)
         topic = TopicFactory.create()
@@ -395,7 +395,7 @@ class TestPublicationAdminAuditLogging(WebTest):
 
         form = changelist.forms["changelist-form"]
         form["_selected_action"] = [publication.pk]
-        form["action"] = "revoke_instance"
+        form["action"] = "revoke"
 
         with freeze_time("2024-09-28T00:14:00-00:00"):
             form.submit()
@@ -967,7 +967,7 @@ class TestDocumentAdminAuditLogging(WebTest):
 
             self.assertEqual(update_log.extra_data, expected_data)
 
-    def test_document_revoke_instance_action_update_log(self):
+    def test_document_revoke_action_update_log(self):
         publication = PublicationFactory.create()
         identifier = f"https://www.openzaak.nl/documenten/{str(uuid.uuid4())}"
         with freeze_time("2024-09-25T14:00:00-00:00"):
@@ -988,7 +988,7 @@ class TestDocumentAdminAuditLogging(WebTest):
         form = changelist.forms["changelist-form"]
 
         form["_selected_action"] = [document.pk]
-        form["action"] = "revoke_instance"
+        form["action"] = "revoke"
 
         with freeze_time("2024-09-29T14:00:00-00:00"):
             form.submit(name="_save")
@@ -1213,7 +1213,7 @@ class TestTopicAdminAuditLogging(WebTest):
 
             self.assertEqual(update_log.extra_data, expected_data)
 
-    def test_topic_revoke_instance_action_update_log(self):
+    def test_topic_revoke_action_update_log(self):
         with freeze_time("2024-09-24T12:00:00-00:00"):
             topic = TopicFactory.create(
                 officiele_titel="Lorem Ipsum",
@@ -1229,7 +1229,7 @@ class TestTopicAdminAuditLogging(WebTest):
         form = changelist.forms["changelist-form"]
 
         form["_selected_action"] = [topic.pk]
-        form["action"] = "revoke_instance"
+        form["action"] = "revoke"
 
         with freeze_time("2024-09-29T14:00:00-00:00"):
             form.submit(name="_save")

--- a/src/woo_publications/publications/tests/test_admin_logging.py
+++ b/src/woo_publications/publications/tests/test_admin_logging.py
@@ -320,7 +320,6 @@ class TestPublicationAdminAuditLogging(WebTest):
                 "_cached_object_repr": "title one",
             }
 
-            self.maxDiff = None
             self.assertEqual(update_publication_log.extra_data, expected_data)
 
         with self.subTest("update document audit logging"):
@@ -342,6 +341,124 @@ class TestPublicationAdminAuditLogging(WebTest):
                     "identifier": "http://example.com/1",
                     "publicatie": publication.id,
                     "publicatiestatus": PublicationStatusOptions.revoked,
+                    "bestandsnaam": "unknown.bin",
+                    "creatiedatum": "2024-10-17",
+                    "omschrijving": "",
+                    "document_uuid": None,
+                    "bestandsomvang": 0,
+                    "verkorte_titel": "",
+                    "bestandsformaat": "unknown",
+                    "officiele_titel": "title",
+                    "document_service": None,
+                    "registratiedatum": "2024-09-27T00:14:00Z",
+                    "laatst_gewijzigd_datum": "2024-09-28T00:14:00Z",
+                    "soort_handeling": DocumentActionTypeOptions.declared,
+                },
+                "_cached_object_repr": "title",
+            }
+
+            self.assertEqual(update_publication_log.extra_data, expected_data)
+
+    def test_publication_revoke_instance_action_log(self):
+        assert not TimelineLogProxy.objects.exists()
+        ic, ic2 = InformationCategoryFactory.create_batch(2)
+        topic = TopicFactory.create()
+        organisation = OrganisationFactory.create(is_actief=True)
+        with freeze_time("2024-09-27T00:14:00-00:00"):
+            publication = PublicationFactory.create(
+                publisher=organisation,
+                verantwoordelijke=organisation,
+                opsteller=organisation,
+                informatie_categorieen=[ic, ic2],
+                onderwerpen=[topic],
+                officiele_titel="title one",
+                verkorte_titel="one",
+                omschrijving="Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                bron_bewaartermijn="Selectielijst gemeenten 2020",
+                archiefnominatie=ArchiveNominationChoices.retain,
+                archiefactiedatum="2025-01-01",
+                publicatiestatus=PublicationStatusOptions.published,
+            )
+            published_document = DocumentFactory.create(
+                publicatie=publication,
+                publicatiestatus=PublicationStatusOptions.published,
+                identifier="http://example.com/1",
+                officiele_titel="title",
+                creatiedatum="2024-10-17",
+            )
+
+        changelist = self.app.get(
+            reverse("admin:publications_publication_changelist"),
+            user=self.user,
+        )
+        self.assertEqual(changelist.status_code, 200)
+
+        form = changelist.forms["changelist-form"]
+        form["_selected_action"] = [publication.pk]
+        form["action"] = "revoke_instance"
+
+        with freeze_time("2024-09-28T00:14:00-00:00"):
+            form.submit()
+
+        self.assertEqual(TimelineLogProxy.objects.count(), 2)
+
+        with self.subTest("update publication audit logging"):
+            update_publication_log = TimelineLogProxy.objects.for_object(  # pyright: ignore[reportAttributeAccessIssue]
+                publication
+            ).get(
+                extra_data__event=Events.update
+            )
+
+            expected_data = {
+                "event": Events.update,
+                "acting_user": {
+                    "identifier": self.user.id,
+                    "display_name": self.user.get_full_name(),
+                },
+                "object_data": {
+                    "id": publication.pk,
+                    "informatie_categorieen": [ic.pk, ic2.pk],
+                    "onderwerpen": [topic.pk],
+                    "laatst_gewijzigd_datum": "2024-09-28T00:14:00Z",
+                    "officiele_titel": "title one",
+                    "omschrijving": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                    "opsteller": organisation.pk,
+                    "publicatiestatus": PublicationStatusOptions.revoked,  # updated to revoked
+                    "publisher": organisation.pk,
+                    "registratiedatum": "2024-09-27T00:14:00Z",
+                    "uuid": str(publication.uuid),
+                    "verantwoordelijke": organisation.pk,
+                    "verkorte_titel": "one",
+                    "bron_bewaartermijn": "Selectielijst gemeenten 2020",
+                    "selectiecategorie": "",
+                    "archiefnominatie": ArchiveNominationChoices.retain,
+                    "archiefactiedatum": "2025-01-01",
+                    "toelichting_bewaartermijn": "",
+                },
+                "_cached_object_repr": "title one",
+            }
+
+            self.assertEqual(update_publication_log.extra_data, expected_data)
+
+        with self.subTest("update document audit logging"):
+            update_publication_log = TimelineLogProxy.objects.for_object(  # pyright: ignore[reportAttributeAccessIssue]
+                published_document
+            ).get()
+
+            expected_data = {
+                "event": Events.update,
+                "acting_user": {
+                    "identifier": self.user.id,
+                    "display_name": self.user.get_full_name(),
+                },
+                "object_data": {
+                    "id": published_document.pk,
+                    "lock": "",
+                    "upload_complete": False,
+                    "uuid": str(published_document.uuid),
+                    "identifier": "http://example.com/1",
+                    "publicatie": publication.id,
+                    "publicatiestatus": PublicationStatusOptions.revoked,  # updated to revoked
                     "bestandsnaam": "unknown.bin",
                     "creatiedatum": "2024-10-17",
                     "omschrijving": "",
@@ -850,6 +967,65 @@ class TestDocumentAdminAuditLogging(WebTest):
 
             self.assertEqual(update_log.extra_data, expected_data)
 
+    def test_document_revoke_instance_action_update_log(self):
+        publication = PublicationFactory.create()
+        identifier = f"https://www.openzaak.nl/documenten/{str(uuid.uuid4())}"
+        with freeze_time("2024-09-25T14:00:00-00:00"):
+            document = DocumentFactory.create(
+                publicatie=publication,
+                identifier=identifier,
+                publicatiestatus=PublicationStatusOptions.published,
+                officiele_titel="title one",
+                verkorte_titel="one",
+                omschrijving="Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                creatiedatum="2024-11-11",
+            )
+
+        changelist = self.app.get(
+            reverse("admin:publications_document_changelist"),
+            user=self.user,
+        )
+        form = changelist.forms["changelist-form"]
+
+        form["_selected_action"] = [document.pk]
+        form["action"] = "revoke_instance"
+
+        with freeze_time("2024-09-29T14:00:00-00:00"):
+            form.submit(name="_save")
+
+        with self.subTest("update audit logging"):
+            update_log = TimelineLogProxy.objects.get()
+            expected_data = {
+                "event": Events.update,
+                "acting_user": {
+                    "identifier": self.user.id,
+                    "display_name": self.user.get_full_name(),
+                },
+                "object_data": {
+                    "id": document.pk,
+                    "lock": "",
+                    "upload_complete": False,
+                    "uuid": str(document.uuid),
+                    "identifier": identifier,
+                    "publicatie": publication.pk,
+                    "publicatiestatus": PublicationStatusOptions.revoked,  # updated
+                    "bestandsnaam": "unknown.bin",
+                    "creatiedatum": "2024-11-11",
+                    "omschrijving": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                    "document_uuid": None,
+                    "bestandsomvang": 0,
+                    "verkorte_titel": "one",
+                    "bestandsformaat": "unknown",
+                    "officiele_titel": "title one",
+                    "document_service": None,
+                    "registratiedatum": "2024-09-25T14:00:00Z",
+                    "laatst_gewijzigd_datum": "2024-09-29T14:00:00Z",
+                    "soort_handeling": DocumentActionTypeOptions.declared,
+                },
+                "_cached_object_repr": "title one",
+            }
+            self.assertEqual(update_log.extra_data, expected_data)
+
     def test_document_admin_delete(self):
         publication = PublicationFactory.create()
         identifier = f"https://www.openzaak.nl/documenten/{str(uuid.uuid4())}"
@@ -1033,6 +1209,51 @@ class TestTopicAdminAuditLogging(WebTest):
                     "laatst_gewijzigd_datum": "2024-09-27T12:00:00Z",
                 },
                 "_cached_object_repr": "changed official title",
+            }
+
+            self.assertEqual(update_log.extra_data, expected_data)
+
+    def test_topic_revoke_instance_action_update_log(self):
+        with freeze_time("2024-09-24T12:00:00-00:00"):
+            topic = TopicFactory.create(
+                officiele_titel="Lorem Ipsum",
+                omschrijving="Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                publicatiestatus=PublicationStatusOptions.published,
+                promoot=True,
+            )
+
+        changelist = self.app.get(
+            reverse("admin:publications_topic_changelist"),
+            user=self.user,
+        )
+        form = changelist.forms["changelist-form"]
+
+        form["_selected_action"] = [topic.pk]
+        form["action"] = "revoke_instance"
+
+        with freeze_time("2024-09-29T14:00:00-00:00"):
+            form.submit(name="_save")
+
+        with self.subTest("update audit logging"):
+            update_log = TimelineLogProxy.objects.get()
+            expected_data = {
+                "event": Events.update,
+                "acting_user": {
+                    "identifier": self.user.id,
+                    "display_name": self.user.get_full_name(),
+                },
+                "object_data": {
+                    "id": topic.pk,
+                    "uuid": str(topic.uuid),
+                    "afbeelding": topic.afbeelding.name,
+                    "officiele_titel": "Lorem Ipsum",
+                    "omschrijving": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                    "publicatiestatus": PublicationStatusOptions.revoked,  # updated
+                    "promoot": True,
+                    "registratiedatum": "2024-09-24T12:00:00Z",
+                    "laatst_gewijzigd_datum": "2024-09-29T14:00:00Z",
+                },
+                "_cached_object_repr": "Lorem Ipsum",
             }
 
             self.assertEqual(update_log.extra_data, expected_data)


### PR DESCRIPTION
Fixes #51

**Changes**

Added admin action to revoke the publication status.
- When using this action on publications they also revoke the linked documents just as you save the form itself.
- Added logging for the instances that get revoked
- Delete the revoked instances from GPP-Zoeken
