### PR TITLE
:bug: [#267] Add missing waardelijst identifiers for documenthandelingen

### DIFF
--- a/src/woo_publications/api/openapi.yaml
+++ b/src/woo_publications/api/openapi.yaml
@@ -1919,6 +1919,10 @@ components:
           allOf:
           - $ref: '#/components/schemas/SoortHandelingEnum'
           default: vaststelling
+        identifier:
+          type: string
+          format: uri
+          readOnly: true
         atTime:
           type: string
           format: date-time
@@ -1930,6 +1934,7 @@ components:
           description: De unieke identificatie van de organisatie.
       required:
       - atTime
+      - identifier
       - wasAssciatedWith
     DocumentStatus:
       type: object

--- a/src/woo_publications/publications/api/serializers.py
+++ b/src/woo_publications/publications/api/serializers.py
@@ -69,6 +69,7 @@ class DocumentActionSerializer(serializers.Serializer):
         choices=DocumentActionTypeOptions.choices,
         default=DocumentActionTypeOptions.declared,
     )
+    identifier = serializers.URLField(read_only=True)
     at_time = serializers.DateTimeField(
         read_only=True,
     )

--- a/src/woo_publications/publications/constants.py
+++ b/src/woo_publications/publications/constants.py
@@ -1,3 +1,5 @@
+from typing import Mapping
+
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
@@ -12,3 +14,18 @@ class DocumentActionTypeOptions(models.TextChoices):
     signed = "ondertekening", _("Signed")
     received = "ontvangst", _("Received")
     declared = "vaststelling", _("Declared")
+
+
+# Taken from PLOOI documenthandelingen on
+# https://standaarden.overheid.nl/tooi/waardelijsten/expression?lijst_uri=https%3A%2F%2Fidentifier.overheid.nl%2Ftooi%2Fset%2Fccw_plooi_documenthandelingen%2F2
+# and https://repository.officiele-overheidspublicaties.nl/waardelijsten/ccw_plooi_documenthandelingen/2/json/ccw_plooi_documenthandelingen_2.json
+DOCUMENT_ACTION_TOOI_IDENTIFIERS: Mapping[DocumentActionTypeOptions, str] = {
+    DocumentActionTypeOptions.signed: "https://identifier.overheid.nl/tooi/def/thes/kern/c_e1ec050e",
+    DocumentActionTypeOptions.received: "https://identifier.overheid.nl/tooi/def/thes/kern/c_dfcee535",
+    DocumentActionTypeOptions.declared: "https://identifier.overheid.nl/tooi/def/thes/kern/c_641ecd76",
+}
+
+# sanity check
+assert all(
+    value in DOCUMENT_ACTION_TOOI_IDENTIFIERS for value in DocumentActionTypeOptions
+), "Not all document action types are mapped1"

--- a/src/woo_publications/publications/models.py
+++ b/src/woo_publications/publications/models.py
@@ -40,7 +40,11 @@ from woo_publications.utils.validators import (
 )
 
 from .archiving import get_retention_informatie_category
-from .constants import DocumentActionTypeOptions, PublicationStatusOptions
+from .constants import (
+    DOCUMENT_ACTION_TOOI_IDENTIFIERS,
+    DocumentActionTypeOptions,
+    PublicationStatusOptions,
+)
 from .typing import DocumentActions
 
 # when the document isn't specified both the service and uuid needs to be unset
@@ -507,6 +511,7 @@ class Document(ModelOwnerMixin, models.Model):
         return [
             {
                 "soort_handeling": self.soort_handeling,
+                "identifier": DOCUMENT_ACTION_TOOI_IDENTIFIERS[self.soort_handeling],
                 "at_time": self.registratiedatum,
                 "was_assciated_with": (
                     self.publicatie.verantwoordelijke.uuid

--- a/src/woo_publications/publications/tests/test_document_api_endpoints.py
+++ b/src/woo_publications/publications/tests/test_document_api_endpoints.py
@@ -142,6 +142,7 @@ class DocumentApiReadTestsCase(TokenAuthMixin, APITestCaseMixin, APITestCase):
             documenthandelingen = [
                 {
                     "soortHandeling": DocumentActionTypeOptions.declared,
+                    "identifier": "https://identifier.overheid.nl/tooi/def/thes/kern/c_641ecd76",
                     "atTime": "2024-09-24T14:00:00+02:00",
                     "wasAssciatedWith": None,
                 }
@@ -171,6 +172,7 @@ class DocumentApiReadTestsCase(TokenAuthMixin, APITestCaseMixin, APITestCase):
             documenthandelingen = [
                 {
                     "soortHandeling": DocumentActionTypeOptions.declared,
+                    "identifier": "https://identifier.overheid.nl/tooi/def/thes/kern/c_641ecd76",
                     "atTime": "2024-09-25T14:30:00+02:00",
                     "wasAssciatedWith": str(organisation.uuid),
                 }
@@ -1013,6 +1015,7 @@ class DocumentApiReadTestsCase(TokenAuthMixin, APITestCaseMixin, APITestCase):
         documenthandelingen = [
             {
                 "soortHandeling": DocumentActionTypeOptions.declared,
+                "identifier": "https://identifier.overheid.nl/tooi/def/thes/kern/c_641ecd76",
                 "atTime": "2024-09-25T14:30:00+02:00",
                 "wasAssciatedWith": None,
             }
@@ -1346,6 +1349,7 @@ class DocumentApiCreateTests(VCRMixin, TokenAuthMixin, APITestCase):
                 [
                     {
                         "soortHandeling": DocumentActionTypeOptions.signed,
+                        "identifier": "https://identifier.overheid.nl/tooi/def/thes/kern/c_e1ec050e",
                         "atTime": "2024-11-13T16:00:00+01:00",
                         "wasAssciatedWith": str(organisation.uuid),
                     }
@@ -1422,6 +1426,7 @@ class DocumentApiCreateTests(VCRMixin, TokenAuthMixin, APITestCase):
                 [
                     {
                         "soortHandeling": DocumentActionTypeOptions.declared,
+                        "identifier": "https://identifier.overheid.nl/tooi/def/thes/kern/c_641ecd76",
                         "atTime": data["registratiedatum"],
                         "wasAssciatedWith": str(organisation.uuid),
                     }

--- a/src/woo_publications/publications/typing.py
+++ b/src/woo_publications/publications/typing.py
@@ -7,6 +7,7 @@ from .constants import DocumentActionTypeOptions
 
 class DocumentAction(TypedDict):
     soort_handeling: DocumentActionTypeOptions
+    identifier: str
     at_time: datetime
     was_assciated_with: UUID | None
 


### PR DESCRIPTION
Fixes #

**Changes**

* Added constant mapping enum to TOOI identifier
* Include identifier in serializer/API output for sitemap generation

