### PR TITLE
Set up django-upgrade-check

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,6 +11,7 @@ django-rosetta
 django-solo
 django-timeline-logger
 django-treebeard
+django-upgrade-check
 
 # DRF & other API tooling
 open-api-framework

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -97,6 +97,7 @@ django==4.2.20
     #   django-timeline-logger
     #   django-treebeard
     #   django-two-factor-auth
+    #   django-upgrade-check
     #   djangorestframework
     #   djangorestframework-inclusions
     #   djangorestframework-recursive
@@ -183,6 +184,8 @@ django-treebeard==4.7.1
     # via -r requirements/base.in
 django-two-factor-auth==1.17.0
     # via maykin-2fa
+django-upgrade-check==1.1.0
+    # via -r requirements/base.in
 djangorestframework==3.15.2
     # via
     #   commonground-api-common
@@ -354,6 +357,8 @@ rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
+semantic-version==2.10.0
+    # via django-upgrade-check
 sentry-sdk==2.14.0
     # via open-api-framework
 six==1.16.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -164,6 +164,7 @@ django==4.2.20
     #   django-timeline-logger
     #   django-treebeard
     #   django-two-factor-auth
+    #   django-upgrade-check
     #   djangorestframework
     #   djangorestframework-inclusions
     #   djangorestframework-recursive
@@ -326,6 +327,10 @@ django-two-factor-auth==1.17.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   maykin-2fa
+django-upgrade-check==1.1.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 django-webtest==1.9.12
     # via -r requirements/test-tools.in
 djangorestframework==3.15.2
@@ -706,6 +711,11 @@ rpds-py==0.20.0
     #   referencing
 ruff==0.11.8
     # via -r requirements/test-tools.in
+semantic-version==2.10.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   django-upgrade-check
 sentry-sdk==2.14.0
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -187,6 +187,7 @@ django==4.2.20
     #   django-timeline-logger
     #   django-treebeard
     #   django-two-factor-auth
+    #   django-upgrade-check
     #   djangorestframework
     #   djangorestframework-inclusions
     #   djangorestframework-recursive
@@ -353,6 +354,10 @@ django-two-factor-auth==1.17.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   maykin-2fa
+django-upgrade-check==1.1.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 django-webtest==1.9.12
     # via
     #   -c requirements/ci.txt
@@ -779,6 +784,11 @@ ruff==0.11.8
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+semantic-version==2.10.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   django-upgrade-check
 sentry-sdk==2.14.0
     # via
     #   -c requirements/ci.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -183,6 +183,7 @@ django==4.2.20
     #   django-timeline-logger
     #   django-treebeard
     #   django-two-factor-auth
+    #   django-upgrade-check
     #   djangorestframework
     #   djangorestframework-inclusions
     #   djangorestframework-recursive
@@ -355,6 +356,10 @@ django-two-factor-auth==1.17.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   maykin-2fa
+django-upgrade-check==1.1.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 django-webtest==1.9.12
     # via
     #   -c requirements/ci.txt
@@ -761,6 +766,11 @@ ruff==0.11.8
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+semantic-version==2.10.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   django-upgrade-check
 sentry-sdk==2.14.0
     # via
     #   -c requirements/ci.txt

--- a/src/woo_publications/conf/base.py
+++ b/src/woo_publications/conf/base.py
@@ -3,6 +3,7 @@ from django.core import validators
 from django.utils.translation import gettext_lazy as _
 
 from open_api_framework.conf.base import *  # noqa
+from upgrade_check import UpgradeCheck, VersionRange
 from vng_api_common.conf.api import BASE_REST_FRAMEWORK
 
 from .utils import config
@@ -23,6 +24,7 @@ INSTALLED_APPS = INSTALLED_APPS + [
     "hijack.contrib.admin",
     "timeline_logger",
     "treebeard",
+    "upgrade_check",
     # Project applications.
     "woo_publications.accounts",
     "woo_publications.api",
@@ -321,3 +323,10 @@ CELERY_TASK_ACKS_LATE = True
 # operation, leading to idle workers and backed-up workers. The `-O fair` option
 # *should* have the same effect...
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1
+
+#
+# DJANGO-UPGRADE-CHECK
+#
+UPGRADE_CHECK_PATHS = {
+    "1.2.0": UpgradeCheck(VersionRange(minimum="1.0.0")),
+}


### PR DESCRIPTION
So that we're prepared for when we need to gate certain upgrade paths in the future. This now records 'version deploys'.