### PR TITLE
Feedback processing for changing owners of publications/documents

### DIFF
--- a/src/woo_publications/accounts/admin.py
+++ b/src/woo_publications/accounts/admin.py
@@ -64,4 +64,10 @@ class UserAdmin(AdminAuditLogMixin, HijackUserAdminMixin, _UserAdmin):
 class OrganisationMemberAdmin(AdminAuditLogMixin, admin.ModelAdmin):
     list_display = ("identifier", "naam")
     search_fields = ("identifier",)
-    readonly_fields = ("identifier",)
+
+    def get_readonly_fields(self, request, obj=None):
+        read_only_fields = super().get_readonly_fields(request, obj)
+        if obj:
+            read_only_fields = ("identifier",)
+
+        return read_only_fields

--- a/src/woo_publications/accounts/tests/test_organisation_member_admin.py
+++ b/src/woo_publications/accounts/tests/test_organisation_member_admin.py
@@ -46,6 +46,51 @@ class TestOrganisationMemberAdmin(WebTest):
         self.assertContains(search_response, "field-naam", 1)
         self.assertContains(search_response, "second org member", 1, html=True)
 
+    def test_organisation_member_admin_create(self):
+        response = self.app.get(
+            reverse("admin:accounts_organisationmember_add"),
+            user=self.user,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        form = response.forms["organisationmember_form"]
+        form["identifier"] = "identifier"
+        form["naam"] = "naam"
+
+        form.submit(name="_save")
+
+        self.assertTrue(
+            OrganisationMember.objects.filter(
+                identifier="identifier", naam="naam"
+            ).exists()
+        )
+
+    def test_organisation_member_admin_update(self):
+        organisation_member = OrganisationMemberFactory.create(
+            identifier="one", naam="first org member"
+        )
+
+        response = self.app.get(
+            reverse(
+                "admin:accounts_organisationmember_change",
+                kwargs={"object_id": organisation_member.pk},
+            ),
+            user=self.user,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        form = response.forms["organisationmember_form"]
+        self.assertNotIn("identifier", form.fields)
+        form["naam"] = "change"
+
+        submit_response = form.submit(name="_save")
+
+        self.assertEqual(submit_response.status_code, 302)
+        organisation_member.refresh_from_db()
+        self.assertEqual(organisation_member.naam, "change")
+
     def test_organisation_member_admin_delete(self):
         org_member = OrganisationMemberFactory.create(
             identifier="one", naam="first org member"

--- a/src/woo_publications/publications/admin.py
+++ b/src/woo_publications/publications/admin.py
@@ -334,13 +334,13 @@ class PublicationAdmin(AdminAuditLogMixin, admin.ModelAdmin):
                     "publisher",
                     "verantwoordelijke",
                     "opsteller",
-                    "eigenaar",
                     "officiele_titel",
                     "verkorte_titel",
                     "omschrijving",
                     "publicatiestatus",
                     "registratiedatum",
                     "laatst_gewijzigd_datum",
+                    "eigenaar",
                     "uuid",
                 )
             },
@@ -564,7 +564,6 @@ class DocumentAdmin(AdminAuditLogMixin, admin.ModelAdmin):
                 "fields": (
                     "publicatie",
                     "identifier",
-                    "eigenaar",
                     "officiele_titel",
                     "verkorte_titel",
                     "omschrijving",
@@ -575,6 +574,7 @@ class DocumentAdmin(AdminAuditLogMixin, admin.ModelAdmin):
                     "publicatiestatus",
                     "registratiedatum",
                     "laatst_gewijzigd_datum",
+                    "eigenaar",
                     "uuid",
                 )
             },


### PR DESCRIPTION
Fixes #260

**Changes**

- Made the identifier field in the  organisation member admin page editable during creation.
- changed the location of the owner field in the documenten/publicaties admin page
- added missing tests for the organisation member admin 
