### PR TITLE
Empty concept bug fixes

### DIFF
--- a/src/woo_publications/publications/api/serializers.py
+++ b/src/woo_publications/publications/api/serializers.py
@@ -641,6 +641,8 @@ class PublicationSerializer(serializers.ModelSerializer[Publication]):
                     # Ensure that officiele_titel remains required.
                     if field != "officiele_titel":
                         fields[field].required = False
+                        fields[field].allow_null = True
+                        fields[field].allow_empty = True  # pyright: ignore[reportAttributeAccessIssue]
 
         assert fields["publicatiestatus"].help_text
         fsm_field = Publication._meta.get_field("publicatiestatus")

--- a/src/woo_publications/publications/models.py
+++ b/src/woo_publications/publications/models.py
@@ -882,6 +882,13 @@ class Document(ConcurrentTransitionMixin, models.Model):
         # Resolve the 'informatieobjecttype' for the Documents API to use.
         # XXX: if there are multiple, which to pick?
         information_category = self.publicatie.informatie_categorieen.first()
+        # TODO: remove this hotfix #315
+        if not information_category:
+            # Now that IC's can be empty because of concept publications.
+            # select a dummy IC to be selected as the informatieobjecttype
+            # within open-zaak.
+            information_category = InformationCategory.objects.first()
+
         assert isinstance(information_category, InformationCategory)
         iot_path = reverse(
             "catalogi-informatieobjecttypen-detail",

--- a/src/woo_publications/publications/tests/test_document_api_endpoints.py
+++ b/src/woo_publications/publications/tests/test_document_api_endpoints.py
@@ -1535,6 +1535,42 @@ class DocumentApiCreateTests(VCRMixin, TokenAuthMixin, APITestCase):
             detail_data = detail.json()
             self.assertTrue(detail_data["locked"])
 
+    def test_create_concept_document_with_a_publication_with_no_ic(self):
+        organisation = OrganisationFactory.create()
+        publication = PublicationFactory.create(
+            informatie_categorieen=[],
+            verantwoordelijke=organisation,
+            publicatiestatus=PublicationStatusOptions.concept
+        )
+        endpoint = reverse("api:document-list")
+        body = {
+            "identifier": "WOO-P/0042",
+            "publicatie": publication.uuid,
+            "officieleTitel": "Testdocument WOO-P + Open Zaak",
+            "verkorteTitel": "Testdocument",
+            "omschrijving": "Testing 123",
+            "creatiedatum": "2024-11-05",
+            "bestandsformaat": "unknown",
+            "bestandsnaam": "unknown.bin",
+            "bestandsomvang": 10,
+            "documenthandelingen": [
+                {
+                    "soortHandeling": DocumentActionTypeOptions.signed,
+                }
+            ],
+        }
+
+        response = self.client.post(
+            endpoint,
+            data=body,
+            headers={
+                **AUDIT_HEADERS,
+                "Host": "host.docker.internal:8000",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
     def test_create_document_without_document_handelingen_saves_with_default_options(
         self,
     ):

--- a/src/woo_publications/publications/tests/test_document_api_endpoints.py
+++ b/src/woo_publications/publications/tests/test_document_api_endpoints.py
@@ -1540,7 +1540,7 @@ class DocumentApiCreateTests(VCRMixin, TokenAuthMixin, APITestCase):
         publication = PublicationFactory.create(
             informatie_categorieen=[],
             verantwoordelijke=organisation,
-            publicatiestatus=PublicationStatusOptions.concept
+            publicatiestatus=PublicationStatusOptions.concept,
         )
         endpoint = reverse("api:document-list")
         body = {

--- a/src/woo_publications/publications/tests/test_publications_api.py
+++ b/src/woo_publications/publications/tests/test_publications_api.py
@@ -2090,6 +2090,24 @@ class PublicationApiRequiredFieldsTestCase(TokenAuthMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    def test_update_concept_with_only_officiele_titel(self):
+        publication = PublicationFactory.create(
+            officiele_titel="title one",
+            publicatiestatus=PublicationStatusOptions.concept,
+        )
+        url = reverse(
+            "api:publication-detail",
+            kwargs={"uuid": str(publication.uuid)},
+        )
+        data = {
+            "publicatiestatus": PublicationStatusOptions.concept,
+            "officieleTitel": "update",
+        }
+
+        response = self.client.put(url, data, headers=AUDIT_HEADERS)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_create_publication_fields_empty(self):
         url = reverse("api:publication-list")
         with self.subTest("create concept publication doesn't raise errors"):
@@ -2175,6 +2193,97 @@ class PublicationApiRequiredFieldsTestCase(TokenAuthMixin, APITestCase):
                 data["informatieCategorieen"], [_("This list may not be empty.")]
             )
             self.assertEqual(data["publisher"], [_("This field may not be null.")])
+
+    def test_update_publication_fields_empty(self):
+        organisation_member = OrganisationMemberFactory.create(
+            identifier=AUDIT_HEADERS["AUDIT_USER_ID"],
+            naam=AUDIT_HEADERS["AUDIT_USER_REPRESENTATION"],
+        )
+        with self.subTest("update with empty values doesn't raise errors"):
+            publication = PublicationFactory.create(
+                officiele_titel="title one",
+                publicatiestatus=PublicationStatusOptions.concept,
+                eigenaar=organisation_member,
+            )
+            url = reverse(
+                "api:publication-detail",
+                kwargs={"uuid": str(publication.uuid)},
+            )
+
+            data = {
+                # required:
+                "publicatiestatus": PublicationStatusOptions.concept,
+                "officieleTitel": "update",
+                # allowed empty:
+                "informatieCategorieen": [],
+                "onderwerpen": [],
+                "publisher": "",
+                "verantwoordelijke": "",
+                "opsteller": "",
+                "kenmerken": [],
+                "verkorteTitel": "",
+                "omschrijving": "",
+                "eigenaar": None,
+                "bronBewaartermijn": "",
+                "selectiecategorie": "",
+                "archiefnominatie": "",
+                "archiefactiedatum": None,
+                "toelichtingBewaartermijn": "",
+            }
+
+            response = self.client.put(url, data, headers=AUDIT_HEADERS)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(
+                response.json()["eigenaar"],
+                {
+                    "identifier": "id",
+                    "weergaveNaam": "username",
+                },
+            )
+
+        with self.subTest("update fully empty values doesn't raise errors"):
+            publication = PublicationFactory.create(
+                officiele_titel="title one",
+                publicatiestatus=PublicationStatusOptions.concept,
+                eigenaar=organisation_member,
+            )
+            url = reverse(
+                "api:publication-detail",
+                kwargs={"uuid": str(publication.uuid)},
+            )
+
+            data = {
+                # required:
+                "publicatiestatus": PublicationStatusOptions.concept,
+                "officieleTitel": "update",
+                # allowed empty:
+                "informatieCategorieen": None,
+                "onderwerpen": None,
+                "publisher": "",
+                "verantwoordelijke": "",
+                "opsteller": "",
+                "kenmerken": None,
+                "verkorteTitel": "",
+                "omschrijving": "",
+                "eigenaar": None,
+                "bronBewaartermijn": "",
+                "selectiecategorie": "",
+                "archiefnominatie": "",
+                "archiefactiedatum": None,
+                "toelichtingBewaartermijn": "",
+            }
+
+            response = self.client.put(url, data, headers=AUDIT_HEADERS)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(
+                response.json()["eigenaar"],
+                {
+                    "identifier": "id",
+                    "weergaveNaam": "username",
+                },
+            )
 
     def test_create_publication_status_concept(self):
         url = reverse("api:publication-list")

--- a/src/woo_publications/publications/tests/test_publications_api.py
+++ b/src/woo_publications/publications/tests/test_publications_api.py
@@ -2092,34 +2092,81 @@ class PublicationApiRequiredFieldsTestCase(TokenAuthMixin, APITestCase):
 
     def test_create_publication_fields_empty(self):
         url = reverse("api:publication-list")
-        data = {
-            # required:
-            "publicatiestatus": PublicationStatusOptions.concept,
-            "officieleTitel": "title one",
-            # allowed empty:
-            "informatieCategorieen": [],
-            "onderwerpen": [],
-            "publisher": "",
-            "verantwoordelijke": "",
-            "opsteller": "",
-            "kenmerken": [],
-            "verkorteTitel": "",
-            "omschrijving": "",
-            "eigenaar": None,
-            "bronBewaartermijn": "",
-            "selectiecategorie": "",
-            "archiefnominatie": "",
-            "archiefactiedatum": None,
-            "toelichtingBewaartermijn": "",
-        }
-
         with self.subTest("create concept publication doesn't raise errors"):
+            data = {
+                # required:
+                "publicatiestatus": PublicationStatusOptions.concept,
+                "officieleTitel": "title one",
+                # allowed empty:
+                "informatieCategorieen": [],
+                "onderwerpen": [],
+                "publisher": "",
+                "verantwoordelijke": "",
+                "opsteller": "",
+                "kenmerken": [],
+                "verkorteTitel": "",
+                "omschrijving": "",
+                "eigenaar": None,
+                "bronBewaartermijn": "",
+                "selectiecategorie": "",
+                "archiefnominatie": "",
+                "archiefactiedatum": None,
+                "toelichtingBewaartermijn": "",
+            }
+
+            response = self.client.post(url, data, headers=AUDIT_HEADERS)
+
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        with self.subTest(
+            "create concept publication fully empty doesn't raise errors"
+        ):
+            data = {
+                # required:
+                "publicatiestatus": PublicationStatusOptions.concept,
+                "officieleTitel": "title one",
+                # allowed empty:
+                "informatieCategorieen": None,
+                "onderwerpen": None,
+                "publisher": "",
+                "verantwoordelijke": "",
+                "opsteller": "",
+                "kenmerken": None,
+                "verkorteTitel": "",
+                "omschrijving": "",
+                "eigenaar": None,
+                "bronBewaartermijn": "",
+                "selectiecategorie": "",
+                "archiefnominatie": "",
+                "archiefactiedatum": None,
+                "toelichtingBewaartermijn": "",
+            }
             response = self.client.post(url, data, headers=AUDIT_HEADERS)
 
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         with self.subTest("create published publication doesn't raise errors"):
-            data["publicatiestatus"] = PublicationStatusOptions.published
+            data = {
+                # required:
+                "publicatiestatus": PublicationStatusOptions.published,
+                "officieleTitel": "title one",
+                # allowed empty:
+                "informatieCategorieen": [],
+                "onderwerpen": [],
+                "publisher": "",
+                "verantwoordelijke": "",
+                "opsteller": "",
+                "kenmerken": [],
+                "verkorteTitel": "",
+                "omschrijving": "",
+                "eigenaar": None,
+                "bronBewaartermijn": "",
+                "selectiecategorie": "",
+                "archiefnominatie": "",
+                "archiefactiedatum": None,
+                "toelichtingBewaartermijn": "",
+            }
+
             response = self.client.post(url, data, headers=AUDIT_HEADERS)
 
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/src/woo_publications/publications/tests/vcr_cassettes/test_document_api_endpoints/DocumentApiCreateTests/test_create_concept_document_with_a_publication_with_no_ic.yaml
+++ b/src/woo_publications/publications/tests/vcr_cassettes/test_document_api_endpoints/DocumentApiCreateTests/test_create_concept_document_with_a_publication_with_no_ic.yaml
@@ -1,0 +1,63 @@
+interactions:
+- request:
+    body: '{"identificatie": "25ad10ab-1d9d-4028-9171-d19444af6394", "bronorganisatie":
+      "000000000", "informatieobjecttype": "http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/9aeb7501-3f77-4f36-8c8f-d21f47c2d6e8",
+      "creatiedatum": "2024-11-05", "titel": "Testdocument WOO-P + Open Zaak", "auteur":
+      "GPP-Woo/ODRC", "status": "definitief", "formaat": "application/octet-stream",
+      "taal": "dut", "bestandsnaam": "unknown.bin", "inhoud": null, "bestandsomvang":
+      10, "beschrijving": "Testing 123", "indicatieGebruiksrecht": false}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTc1MDI0NzMzMCwiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.tNIMEeKT-Wuri6Ps3AFRvi3lQYwidsDNZOrQSjLK4w8
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '534'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten
+  response:
+    body:
+      string: '{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/bb37450d-a4c4-4e20-aa5e-5c8c640a2d23","identificatie":"25ad10ab-1d9d-4028-9171-d19444af6394","bronorganisatie":"000000000","creatiedatum":"2024-11-05","titel":"Testdocument
+        WOO-P + Open Zaak","vertrouwelijkheidaanduiding":"openbaar","auteur":"GPP-Woo/ODRC","status":"definitief","formaat":"application/octet-stream","taal":"dut","versie":1,"beginRegistratie":"2025-06-18T11:48:51.116808Z","bestandsnaam":"unknown.bin","inhoud":null,"bestandsomvang":10,"link":"","beschrijving":"Testing
+        123","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/9aeb7501-3f77-4f36-8c8f-d21f47c2d6e8","locked":true,"bestandsdelen":[{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/bestandsdelen/21906763-4ccc-459e-be1c-44a76158f98c","volgnummer":1,"omvang":10,"voltooid":false,"lock":"184a075e2d6f46fbabe008b5a19109f1"}],"trefwoorden":[],"lock":"184a075e2d6f46fbabe008b5a19109f1"}'
+    headers:
+      API-version:
+      - 1.4.2
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1204'
+      Content-Security-Policy:
+      - 'base-uri ''self''; form-action ''self''; worker-src ''self'' blob:; object-src
+        ''none''; frame-ancestors ''none''; font-src ''self'' fonts.gstatic.com; img-src
+        ''self'' data: cdn.redoc.ly cdnjs.cloudflare.com tile.openstreetmap.org; default-src
+        ''self''; connect-src ''self'' raw.githubusercontent.com; script-src ''self''
+        ''unsafe-inline'' cdnjs.cloudflare.com cdn.jsdelivr.net; frame-src ''self'';
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com cdnjs.cloudflare.com
+        cdn.jsdelivr.net'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/bb37450d-a4c4-4e20-aa5e-5c8c640a2d23
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+version: 1


### PR DESCRIPTION
Fixes #263

**Changes**

- Fixed bug where creating a document with a publication that doesn't have a IC raises error
- Improved publication api to now allow fields to be set empty instead of not just being not required.
