### PR TITLE
Hardcoded dummy IC

### DIFF
--- a/src/woo_publications/contrib/documents_api/api.py
+++ b/src/woo_publications/contrib/documents_api/api.py
@@ -20,6 +20,7 @@ from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
 
 from woo_publications.metadata.models import InformationCategory
 
+DUMMY_IC_UUID: UUID = UUID("0f06fded-7e08-437d-9fa2-021841a93842")
 FIXED_DUMMY_IOT_DATA = {
     "vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduidingen.openbaar,
     "begin_geldigheid": "2024-09-01",
@@ -96,7 +97,11 @@ class CatalogiAPIDocumentTypeView(views.APIView):
         **NOTE**: this API endpoint is internal and used in the integration with the
         Documenten API. Publication components are not expected to interact with it.
         """
-        information_category = get_object_or_404(InformationCategory, uuid=uuid)
+        if uuid == DUMMY_IC_UUID:
+            information_category = InformationCategory(uuid=DUMMY_IC_UUID)
+        else:
+            information_category = get_object_or_404(InformationCategory, uuid=uuid)
+
         data = {
             "url": request.build_absolute_uri(request.path),
             "catalogus": request.build_absolute_uri(

--- a/src/woo_publications/contrib/documents_api/tests/test_catalogi_api_informatieobjecttype_view.py
+++ b/src/woo_publications/contrib/documents_api/tests/test_catalogi_api_informatieobjecttype_view.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
+from woo_publications.contrib.documents_api.api import DUMMY_IC_UUID
 from woo_publications.metadata.tests.factories import InformationCategoryFactory
 
 
@@ -29,6 +30,28 @@ class CatalogiAPIDocumentTypeViewTests(APITestCase):
             "url": f"http://testserver{endpoint}",
             "catalogus": "http://testserver/catalogi/api/v1/catalogussen/-fake-",
             "omschrijving": "Raadsbesluit",
+            "vertrouwelijkheidaanduiding": "openbaar",
+            "beginGeldigheid": "2024-09-01",
+            "concept": False,
+            "informatieobjectcategorie": "Wet Open Overheid",
+            "besluittypen": [],
+            "zaaktypen": [],
+        }
+        self.assertEqual(response.json(), expected_data)
+
+    def test_dummy_information_category_exposed_as_documenttype(self):
+        endpoint = reverse(
+            "catalogi-informatieobjecttypen-detail",
+            kwargs={"uuid": DUMMY_IC_UUID},
+        )
+
+        response = self.client.get(endpoint)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_data = {
+            "url": f"http://testserver{endpoint}",
+            "catalogus": "http://testserver/catalogi/api/v1/catalogussen/-fake-",
+            "omschrijving": "",
             "vertrouwelijkheidaanduiding": "openbaar",
             "beginGeldigheid": "2024-09-01",
             "concept": False,

--- a/src/woo_publications/contrib/documents_api/tests/test_documents_api_integration.py
+++ b/src/woo_publications/contrib/documents_api/tests/test_documents_api_integration.py
@@ -27,6 +27,8 @@ from woo_publications.contrib.tests.factories import ServiceFactory
 from woo_publications.metadata.tests.factories import InformationCategoryFactory
 from woo_publications.utils.tests.vcr import VCRMixin
 
+from ..api import DUMMY_IC_UUID
+
 
 class DocumentsApiIntegrationTests(VCRMixin, LiveServerTestCase):
     # host and port must match the service declared in
@@ -57,6 +59,30 @@ class DocumentsApiIntegrationTests(VCRMixin, LiveServerTestCase):
             "bronorganisatie": "000000000",
             "creatiedatum": "2024-09-18",
             "titel": "Test document",
+            "auteur": "Automated test suite",
+            "taal": "ENG",
+            "bestandsomvang": 0,
+        }
+
+        response = client.post("enkelvoudiginformatieobjecten", json=document_data)
+
+        self.assertEqual(response.status_code, 201, response.json())
+
+    def test_can_create_document_with_dummy_informatieobjecttype(self):
+        iot_path = reverse(
+            "catalogi-informatieobjecttypen-detail",
+            kwargs={"uuid": DUMMY_IC_UUID},
+        )
+        iot_url = (
+            furl(self.live_server_url.replace("0.0.0.0", "host.docker.internal"))
+            / iot_path
+        )
+        client = build_client(self.documents_api_service)
+        document_data = {
+            "informatieobjecttype": str(iot_url),
+            "bronorganisatie": "000000000",
+            "creatiedatum": "2024-09-18",
+            "titel": "Test document with dummy IC",
             "auteur": "Automated test suite",
             "taal": "ENG",
             "bestandsomvang": 0,

--- a/src/woo_publications/contrib/documents_api/tests/vcr_cassettes/test_documents_api_integration/DocumentsApiIntegrationTests/test_can_create_document_with_dummy_informatieobjecttype.yaml
+++ b/src/woo_publications/contrib/documents_api/tests/vcr_cassettes/test_documents_api_integration/DocumentsApiIntegrationTests/test_can_create_document_with_dummy_informatieobjecttype.yaml
@@ -1,0 +1,61 @@
+interactions:
+- request:
+    body: '{"informatieobjecttype": "http://host.docker.internal:8100/catalogi/api/v1/informatieobjecttypen/0f06fded-7e08-437d-9fa2-021841a93842",
+      "bronorganisatie": "000000000", "creatiedatum": "2024-09-18", "titel": "Test
+      document with dummy IC", "auteur": "Automated test suite", "taal": "ENG", "bestandsomvang":
+      0}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTc1MjA4MTQ0MSwiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.sMu80UalCeK7oZaAxbQXV21TO3FbuCrLF7ph7B7Yw9A
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '307'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten
+  response:
+    body:
+      string: '{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/50d23455-89c4-4efb-b944-7bb253318f80","identificatie":"DOCUMENT-2024-0000000001","bronorganisatie":"000000000","creatiedatum":"2024-09-18","titel":"Test
+        document with dummy IC","vertrouwelijkheidaanduiding":"openbaar","auteur":"Automated
+        test suite","status":"","formaat":"","taal":"ENG","versie":1,"beginRegistratie":"2025-07-09T17:17:21.763022Z","bestandsnaam":"","inhoud":"http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/50d23455-89c4-4efb-b944-7bb253318f80/download?versie=1","bestandsomvang":0,"link":"","beschrijving":"","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":null,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://host.docker.internal:8100/catalogi/api/v1/informatieobjecttypen/0f06fded-7e08-437d-9fa2-021841a93842","locked":false,"bestandsdelen":[],"trefwoorden":[],"lock":""}'
+    headers:
+      API-version:
+      - 1.4.2
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1044'
+      Content-Security-Policy:
+      - 'frame-ancestors ''none''; object-src ''none''; base-uri ''self''; default-src
+        ''self''; frame-src ''self''; connect-src ''self'' raw.githubusercontent.com;
+        form-action ''self''; img-src ''self'' data: cdn.redoc.ly cdnjs.cloudflare.com
+        tile.openstreetmap.org; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com
+        cdnjs.cloudflare.com cdn.jsdelivr.net; font-src ''self'' fonts.gstatic.com;
+        script-src ''self'' ''unsafe-inline'' cdnjs.cloudflare.com cdn.jsdelivr.net;
+        worker-src ''self'' blob:'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/50d23455-89c4-4efb-b944-7bb253318f80
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/src/woo_publications/publications/models.py
+++ b/src/woo_publications/publications/models.py
@@ -912,6 +912,8 @@ class Document(ConcurrentTransitionMixin, models.Model):
         As a side-effect, this populates ``self.zgw_document``.
         """
 
+        from woo_publications.contrib.documents_api.api import DUMMY_IC_UUID
+
         # Look up which service to use to register the document
         config = GlobalConfiguration.get_solo()
         if (service := config.documents_api_service) is None:
@@ -922,12 +924,11 @@ class Document(ConcurrentTransitionMixin, models.Model):
         # Resolve the 'informatieobjecttype' for the Documents API to use.
         # XXX: if there are multiple, which to pick?
         information_category = self.publicatie.informatie_categorieen.first()
-        # TODO: remove this hotfix #315
         if not information_category:
             # Now that IC's can be empty because of concept publications.
-            # select a dummy IC to be selected as the informatieobjecttype
-            # within open-zaak.
-            information_category = InformationCategory.objects.first()
+            # Assign the hardcoded dummy information category for the generation
+            # of the document_type_url.
+            information_category = InformationCategory(uuid=DUMMY_IC_UUID)
 
         assert isinstance(information_category, InformationCategory)
         iot_path = reverse(

--- a/src/woo_publications/publications/tests/vcr_cassettes/test_document_api_endpoints/DocumentApiCreateTests/test_create_concept_document_with_a_publication_with_no_ic.yaml
+++ b/src/woo_publications/publications/tests/vcr_cassettes/test_document_api_endpoints/DocumentApiCreateTests/test_create_concept_document_with_a_publication_with_no_ic.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"identificatie": "25ad10ab-1d9d-4028-9171-d19444af6394", "bronorganisatie":
-      "000000000", "informatieobjecttype": "http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/9aeb7501-3f77-4f36-8c8f-d21f47c2d6e8",
+    body: '{"identificatie": "6ad59e3f-354a-4bfa-b822-c175077c6c94", "bronorganisatie":
+      "000000000", "informatieobjecttype": "http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/0f06fded-7e08-437d-9fa2-021841a93842",
       "creatiedatum": "2024-11-05", "titel": "Testdocument WOO-P + Open Zaak", "auteur":
       "GPP-Woo/GPP-publicatiebank", "status": "definitief", "formaat": "application/octet-stream",
       "taal": "dut", "bestandsnaam": "unknown.bin", "inhoud": null, "bestandsomvang":
@@ -12,11 +12,11 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTc1MDI0NzMzMCwiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.tNIMEeKT-Wuri6Ps3AFRvi3lQYwidsDNZOrQSjLK4w8
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTc1MjA3MTEzMywiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9._nNef24YHgllPxhaGeft5Tm_HyAT-qfACHTtD9_0Wow
       Connection:
       - keep-alive
       Content-Length:
-      - '534'
+      - '548'
       Content-Type:
       - application/json
       User-Agent:
@@ -25,30 +25,29 @@ interactions:
     uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten
   response:
     body:
-      string: '{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/bb37450d-a4c4-4e20-aa5e-5c8c640a2d23","identificatie":"25ad10ab-1d9d-4028-9171-d19444af6394","bronorganisatie":"000000000","creatiedatum":"2024-11-05","titel":"Testdocument
-        WOO-P + Open Zaak","vertrouwelijkheidaanduiding":"openbaar","auteur":"GPP-Woo/GPP-publicatiebank","status":"definitief","formaat":"application/octet-stream","taal":"dut","versie":1,"beginRegistratie":"2025-06-18T11:48:51.116808Z","bestandsnaam":"unknown.bin","inhoud":null,"bestandsomvang":10,"link":"","beschrijving":"Testing
-        123","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/9aeb7501-3f77-4f36-8c8f-d21f47c2d6e8","locked":true,"bestandsdelen":[{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/bestandsdelen/21906763-4ccc-459e-be1c-44a76158f98c","volgnummer":1,"omvang":10,"voltooid":false,"lock":"184a075e2d6f46fbabe008b5a19109f1"}],"trefwoorden":[],"lock":"184a075e2d6f46fbabe008b5a19109f1"}'
+      string: '{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/d29d9fcb-e54f-491c-a0f0-8da6c7e2774d","identificatie":"6ad59e3f-354a-4bfa-b822-c175077c6c94","bronorganisatie":"000000000","creatiedatum":"2024-11-05","titel":"Testdocument
+        WOO-P + Open Zaak","vertrouwelijkheidaanduiding":"openbaar","auteur":"GPP-Woo/GPP-publicatiebank","status":"definitief","formaat":"application/octet-stream","taal":"dut","versie":1,"beginRegistratie":"2025-07-09T14:25:33.875500Z","bestandsnaam":"unknown.bin","inhoud":null,"bestandsomvang":10,"link":"","beschrijving":"Testing
+        123","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/0f06fded-7e08-437d-9fa2-021841a93842","locked":true,"bestandsdelen":[{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/bestandsdelen/d8671b55-1aa9-408f-bfc6-32729f977147","volgnummer":1,"omvang":10,"voltooid":false,"lock":"fb5bfa6c01a64f4ea3530e17a3eee473"}],"trefwoorden":[],"lock":"fb5bfa6c01a64f4ea3530e17a3eee473"}'
     headers:
       API-version:
       - 1.4.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1204'
+      - '1218'
       Content-Security-Policy:
-      - 'base-uri ''self''; form-action ''self''; worker-src ''self'' blob:; object-src
-        ''none''; frame-ancestors ''none''; font-src ''self'' fonts.gstatic.com; img-src
-        ''self'' data: cdn.redoc.ly cdnjs.cloudflare.com tile.openstreetmap.org; default-src
-        ''self''; connect-src ''self'' raw.githubusercontent.com; script-src ''self''
-        ''unsafe-inline'' cdnjs.cloudflare.com cdn.jsdelivr.net; frame-src ''self'';
-        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com cdnjs.cloudflare.com
-        cdn.jsdelivr.net'
+      - 'frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com
+        cdnjs.cloudflare.com cdn.jsdelivr.net; script-src ''self'' ''unsafe-inline''
+        cdnjs.cloudflare.com cdn.jsdelivr.net; form-action ''self''; default-src ''self'';
+        worker-src ''self'' blob:; base-uri ''self''; frame-src ''self''; connect-src
+        ''self'' raw.githubusercontent.com; img-src ''self'' data: cdn.redoc.ly cdnjs.cloudflare.com
+        tile.openstreetmap.org; font-src ''self'' fonts.gstatic.com; object-src ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/bb37450d-a4c4-4e20-aa5e-5c8c640a2d23
+      - http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/d29d9fcb-e54f-491c-a0f0-8da6c7e2774d
       Referrer-Policy:
       - same-origin
       Vary:
@@ -60,4 +59,55 @@ interactions:
     status:
       code: 201
       message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTc1MjA3MTEzMywiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9._nNef24YHgllPxhaGeft5Tm_HyAT-qfACHTtD9_0Wow
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.4
+    method: GET
+    uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/d29d9fcb-e54f-491c-a0f0-8da6c7e2774d
+  response:
+    body:
+      string: '{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/d29d9fcb-e54f-491c-a0f0-8da6c7e2774d","identificatie":"6ad59e3f-354a-4bfa-b822-c175077c6c94","bronorganisatie":"000000000","creatiedatum":"2024-11-05","titel":"Testdocument
+        WOO-P + Open Zaak","vertrouwelijkheidaanduiding":"openbaar","auteur":"GPP-Woo/GPP-publicatiebank","status":"definitief","formaat":"application/octet-stream","taal":"dut","versie":1,"beginRegistratie":"2025-07-09T14:25:33.875500Z","bestandsnaam":"unknown.bin","inhoud":null,"bestandsomvang":10,"link":"","beschrijving":"Testing
+        123","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/0f06fded-7e08-437d-9fa2-021841a93842","locked":true,"bestandsdelen":[{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/bestandsdelen/d8671b55-1aa9-408f-bfc6-32729f977147","volgnummer":1,"omvang":10,"voltooid":false,"lock":"fb5bfa6c01a64f4ea3530e17a3eee473"}],"trefwoorden":[],"_expand":{}}'
+    headers:
+      API-version:
+      - 1.4.2
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '1189'
+      Content-Security-Policy:
+      - 'frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com
+        cdnjs.cloudflare.com cdn.jsdelivr.net; script-src ''self'' ''unsafe-inline''
+        cdnjs.cloudflare.com cdn.jsdelivr.net; form-action ''self''; default-src ''self'';
+        worker-src ''self'' blob:; base-uri ''self''; frame-src ''self''; connect-src
+        ''self'' raw.githubusercontent.com; img-src ''self'' data: cdn.redoc.ly cdnjs.cloudflare.com
+        tile.openstreetmap.org; font-src ''self'' fonts.gstatic.com; object-src ''none'''
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"2250f42300af827f2f830addaea4a11f"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
 version: 1


### PR DESCRIPTION
Fixes #315

**Changes**

- Added hardcoded dummy object for the CatalogiAPIDocumentTypeView.
- Replaced .first() dummy IC in `register_in_documents_api` for when there isn't any IC connected to the publication

